### PR TITLE
Fix login redirect and update financial_pro role

### DIFF
--- a/src/components/auth/PrivateRoute.jsx
+++ b/src/components/auth/PrivateRoute.jsx
@@ -18,7 +18,7 @@ const PrivateRoute = ({ children, allowedRoles = [], requireAuth = true }) => {
 
   // If auth is required and user isn't signed in, redirect to login
   if (requireAuth && !isSignedIn) {
-    return <Navigate to="/login" state={{ from: location }} replace />;
+    return <Navigate to="/sign-in" state={{ from: location }} replace />;
   }
 
   // If we have role restrictions
@@ -30,7 +30,7 @@ const PrivateRoute = ({ children, allowedRoles = [], requireAuth = true }) => {
       // Redirect to appropriate dashboard based on role
       if (userRole === 'admin' || userRole === 'manager') {
         return <Navigate to="/admin/dashboard" replace />;
-      } else if (userRole === 'financial_pro') {
+      } else if (userRole === 'financial_professional') {
         return <Navigate to="/advisor/dashboard" replace />;
       } else if (userRole === 'client') {
         return <Navigate to="/client/dashboard" replace />;

--- a/src/components/auth/UserRoleManager.jsx
+++ b/src/components/auth/UserRoleManager.jsx
@@ -17,7 +17,7 @@ const TEAM_IDS = [
 const ROLES = [
   { id: 'admin', name: 'Administrator', icon: FiShield },
   { id: 'manager', name: 'Manager', icon: FiUsers },
-  { id: 'financial_pro', name: 'Financial Professional', icon: FiBriefcase },
+  { id: 'financial_professional', name: 'Financial Professional', icon: FiBriefcase },
   { id: 'client', name: 'Client', icon: FiUser }
 ];
 
@@ -192,7 +192,7 @@ const UserRoleManager = ({ userId }) => {
           </select>
         </div>
         
-        {(formData.role === 'manager' || formData.role === 'financial_pro') && (
+        {(formData.role === 'manager' || formData.role === 'financial_professional') && (
           <div>
             <label htmlFor="teamId" className="block text-sm font-medium text-gray-700 mb-2">
               Team

--- a/src/config/routes.jsx
+++ b/src/config/routes.jsx
@@ -18,7 +18,7 @@ import ProjectionsSettings from '../pages/ProjectionsSettings';
 export const ROLES = {
   ADMIN: 'admin',
   MANAGER: 'manager',
-  FINANCIAL_PRO: 'financial_pro',
+  FINANCIAL_PRO: 'financial_professional',
   CLIENT: 'client'
 };
 

--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -5,7 +5,7 @@ import { useAuth as useAuthContext } from '../contexts/AuthContext';
 const ROLES = {
   ADMIN: 'admin',
   MANAGER: 'manager',
-  FINANCIAL_PRO: 'financial_pro',
+  FINANCIAL_PRO: 'financial_professional',
   CLIENT: 'client'
 };
 

--- a/src/pages/Signup.jsx
+++ b/src/pages/Signup.jsx
@@ -66,7 +66,7 @@ const Signup = () => {
       setError('Passwords do not match');
       return false;
     }
-    if (formData.role === 'financial_pro' && !formData.teamId) {
+    if (formData.role === 'financial_professional' && !formData.teamId) {
       setError('Please select a team');
       return false;
     }
@@ -94,7 +94,7 @@ const Signup = () => {
     try {
       // Generate agent code automatically for financial professionals
       let agentCode = '';
-      if (formData.role === 'financial_pro') {
+      if (formData.role === 'financial_professional') {
         agentCode = `FP${Math.floor(Math.random() * 10000).toString().padStart(4, '0')}`;
       }
 
@@ -125,7 +125,7 @@ const Signup = () => {
         
         // Redirect based on role
         setTimeout(() => {
-          if (formData.role === 'financial_pro') {
+          if (formData.role === 'financial_professional') {
             navigate('/advisor/dashboard');
           } else {
             navigate('/client/dashboard');
@@ -151,7 +151,7 @@ const Signup = () => {
     );
   }
 
-  const isFinancialPro = formData.role === 'financial_pro';
+  const isFinancialPro = formData.role === 'financial_professional';
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-primary-50 to-secondary-50 flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
@@ -229,7 +229,7 @@ const Signup = () => {
                   required
                 >
                   <option value="client">Client</option>
-                  <option value="financial_pro">Financial Professional</option>
+                  <option value="financial_professional">Financial Professional</option>
                 </select>
               </div>
 


### PR DESCRIPTION
## Summary
- update PrivateRoute login redirect to `/sign-in`
- change `financial_pro` role string to `financial_professional`
- keep role constant consistent across hooks and routes
- update signup and user role manager components accordingly

## Testing
- `npm run build`
- `npm run lint` *(fails: Invalid option '--ext')*

------
https://chatgpt.com/codex/tasks/task_e_6875297b638c8333a2805323c065d6e9