### PR TITLE
Unify role naming for financial professionals

### DIFF
--- a/src/config/routes.jsx
+++ b/src/config/routes.jsx
@@ -18,7 +18,7 @@ import ProjectionsSettings from '../pages/ProjectionsSettings';
 export const ROLES = {
   ADMIN: 'admin',
   MANAGER: 'manager',
-  FINANCIAL_PRO: 'financial_professional',
+  FINANCIAL_PROFESSIONAL: 'financial_professional',
   CLIENT: 'client'
 };
 
@@ -38,13 +38,13 @@ export const routes = [
     path: '/crm',
     element: <CRMDashboard />,
     requireAuth: true,
-    allowedRoles: [ROLES.ADMIN, ROLES.MANAGER, ROLES.FINANCIAL_PRO]
+    allowedRoles: [ROLES.ADMIN, ROLES.MANAGER, ROLES.FINANCIAL_PROFESSIONAL]
   },
   {
     path: '/clients/:clientId/crm',
     element: <ClientCRM />,
     requireAuth: true,
-    allowedRoles: [ROLES.ADMIN, ROLES.MANAGER, ROLES.FINANCIAL_PRO]
+    allowedRoles: [ROLES.ADMIN, ROLES.MANAGER, ROLES.FINANCIAL_PROFESSIONAL]
   },
   {
     path: '/client-portal',
@@ -62,25 +62,25 @@ export const routes = [
     path: '/clients',
     element: <ClientManagement />,
     requireAuth: true,
-    allowedRoles: [ROLES.ADMIN, ROLES.MANAGER, ROLES.FINANCIAL_PRO]
+    allowedRoles: [ROLES.ADMIN, ROLES.MANAGER, ROLES.FINANCIAL_PROFESSIONAL]
   },
   {
     path: '/clients/:clientId',
     element: <ClientDetails />,
     requireAuth: true,
-    allowedRoles: [ROLES.ADMIN, ROLES.MANAGER, ROLES.FINANCIAL_PRO]
+    allowedRoles: [ROLES.ADMIN, ROLES.MANAGER, ROLES.FINANCIAL_PROFESSIONAL]
   },
   {
     path: '/financial-analysis',
     element: <FinancialAnalysis />,
     requireAuth: true,
-    allowedRoles: [ROLES.ADMIN, ROLES.MANAGER, ROLES.FINANCIAL_PRO]
+    allowedRoles: [ROLES.ADMIN, ROLES.MANAGER, ROLES.FINANCIAL_PROFESSIONAL]
   },
   {
     path: '/financial-analysis/:clientId',
     element: <FinancialAnalysis />,
     requireAuth: true,
-    allowedRoles: [ROLES.ADMIN, ROLES.MANAGER, ROLES.FINANCIAL_PRO]
+    allowedRoles: [ROLES.ADMIN, ROLES.MANAGER, ROLES.FINANCIAL_PROFESSIONAL]
   },
   {
     path: '/clients/:clientId/report',
@@ -91,7 +91,7 @@ export const routes = [
     path: '/proposals',
     element: <ProposalManagement />,
     requireAuth: true,
-    allowedRoles: [ROLES.ADMIN, ROLES.MANAGER, ROLES.FINANCIAL_PRO]
+    allowedRoles: [ROLES.ADMIN, ROLES.MANAGER, ROLES.FINANCIAL_PROFESSIONAL]
   },
   {
     path: '/users',

--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -5,7 +5,7 @@ import { useAuth as useAuthContext } from '../contexts/AuthContext';
 const ROLES = {
   ADMIN: 'admin',
   MANAGER: 'manager',
-  FINANCIAL_PRO: 'financial_professional',
+  FINANCIAL_PROFESSIONAL: 'financial_professional',
   CLIENT: 'client'
 };
 
@@ -19,7 +19,7 @@ export const useAuth = () => {
 
   const isAdmin = user?.role === ROLES.ADMIN;
   const isManager = user?.role === ROLES.MANAGER;
-  const isFinancialPro = user?.role === ROLES.FINANCIAL_PRO;
+  const isFinancialProfessional = user?.role === ROLES.FINANCIAL_PROFESSIONAL;
   const isClient = user?.role === ROLES.CLIENT;
 
   const hasRole = (role) => user?.role === role;
@@ -31,7 +31,7 @@ export const useAuth = () => {
     isSignedIn,
     isAdmin,
     isManager,
-    isFinancialPro,
+    isFinancialProfessional,
     isClient,
     hasRole,
     hasAnyRole,

--- a/src/pages/Signup.jsx
+++ b/src/pages/Signup.jsx
@@ -151,7 +151,7 @@ const Signup = () => {
     );
   }
 
-  const isFinancialPro = formData.role === 'financial_professional';
+  const isFinancialProfessional = formData.role === 'financial_professional';
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-primary-50 to-secondary-50 flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
@@ -349,7 +349,7 @@ const Signup = () => {
               </div>
 
               {/* Team selection only for financial professionals */}
-              {isFinancialPro && (
+              {isFinancialProfessional && (
                 <div>
                   <label htmlFor="teamId" className="block text-sm font-medium text-gray-700 mb-2">
                     Team *


### PR DESCRIPTION
## Summary
- rename FINANCIAL_PRO constants to FINANCIAL_PROFESSIONAL
- update related role checks
- rename helper variable in signup page

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68752c31f9bc8333a327aecf8d4c165d