### PR TITLE
Fix clerk webhook supabase import

### DIFF
--- a/api/clerk-webhook.js
+++ b/api/clerk-webhook.js
@@ -1,8 +1,8 @@
 import { Webhook } from 'svix';
-import { supabase } from '../src/lib/supabase';
+import supabase from '../src/lib/supabase';
 
 export default async function handler(req, res) {
-  // Get the webhook secret from environment variables
+  // Webhook expects CLERK_WEBHOOK_SECRET in environment variables
   const webhookSecret = process.env.CLERK_WEBHOOK_SECRET;
   
   if (!webhookSecret) {


### PR DESCRIPTION
## Summary
- use default `supabase` import in the Clerk webhook
- mention `CLERK_WEBHOOK_SECRET` env var

## Testing
- `npm run lint` *(fails: Invalid option '--ext')*

------
https://chatgpt.com/codex/tasks/task_e_687532c46c308333a0d0887057048a42