### PR TITLE
Handle Clerk init failures

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import logDev from './utils/logDev';
 import { Routes, Route, Navigate } from 'react-router-dom';
 import { useAuth as useClerkAuth } from '@clerk/clerk-react';
@@ -29,8 +29,30 @@ import ProjectionsSettings from './pages/ProjectionsSettings';
 
 function App() {
   const { isLoaded, isSignedIn } = useClerkAuth();
+  const [authError, setAuthError] = useState(null);
+
+  useEffect(() => {
+    if (isLoaded || authError) return;
+    const timer = setTimeout(() => {
+      if (!isLoaded) {
+        setAuthError('Authentication failed to initialize. Please check your environment variables or domain configuration.');
+      }
+    }, 10000);
+    return () => clearTimeout(timer);
+  }, [isLoaded, authError]);
   
   logDev('App rendering, authentication state:', { isLoaded, isSignedIn });
+
+  if (authError) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50">
+        <div className="text-center">
+          <h1 className="text-2xl font-bold text-gray-900 mb-4">Authentication Error</h1>
+          <p className="text-gray-600">{authError}</p>
+        </div>
+      </div>
+    );
+  }
   
   if (!isLoaded) {
     return (

--- a/src/components/auth/ClerkProviderWithRoutes.jsx
+++ b/src/components/auth/ClerkProviderWithRoutes.jsx
@@ -1,14 +1,27 @@
-import React from 'react';
-import { ClerkProvider } from '@clerk/clerk-react';
+import React, { useState, useEffect } from 'react';
+import { ClerkProvider, useAuth } from '@clerk/clerk-react';
 import { useNavigate } from 'react-router-dom';
 import LoadingSpinner from '../ui/LoadingSpinner';
 
 const ClerkProviderWithRoutes = ({ children }) => {
   const navigate = useNavigate();
+  const { isLoaded } = useAuth();
+  const [initError, setInitError] = useState(null);
   
   // Get Clerk configuration from environment variables
   const CLERK_PUBLISHABLE_KEY = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY;
-  
+
+
+  useEffect(() => {
+    if (isLoaded || initError) return;
+    const timer = setTimeout(() => {
+      if (!isLoaded) {
+        setInitError('Failed to initialize authentication. Please check your environment variables or domain configuration.');
+      }
+    }, 10000);
+    return () => clearTimeout(timer);
+  }, [isLoaded, initError]);
+
   if (!CLERK_PUBLISHABLE_KEY) {
     console.error('Missing Clerk configuration. Please check your environment variables.');
     return (
@@ -25,10 +38,26 @@ const ClerkProviderWithRoutes = ({ children }) => {
     );
   }
 
+  if (initError) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50">
+        <div className="text-center">
+          <h1 className="text-2xl font-bold text-gray-900 mb-4">Authentication Error</h1>
+          <p className="text-gray-600">{initError}</p>
+          <p className="text-sm text-gray-500 mt-2">Please check your environment variables or domain configuration.</p>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <ClerkProvider
       publishableKey={CLERK_PUBLISHABLE_KEY}
       navigate={(to) => navigate(to)}
+      onError={(err) => {
+        console.error('Clerk initialization error:', err);
+        setInitError(err.errors?.[0]?.longMessage || err.message || 'Unknown error');
+      }}
       loading={
         <div className="min-h-screen flex items-center justify-center bg-gray-50">
           <LoadingSpinner size="lg" />


### PR DESCRIPTION
## Summary
- detect Clerk initialization errors in `ClerkProviderWithRoutes`
- show authentication errors in `App.jsx`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6875ba83a4988333a95c809848d7c786