### PR TITLE
Fix README env list

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,8 +4,10 @@ VITE_SUPABASE_ANON_KEY=your-supabase-anon-key
 
 # Clerk Configuration
 VITE_CLERK_PUBLISHABLE_KEY=your-clerk-publishable-key
-VITE_CLERK_SECRET_KEY=your-clerk-secret-key
-VITE_CLERK_FRONTEND_API=your-clerk-frontend-api
+# The following Clerk variables are not used by this project but may appear in
+# other Clerk examples. They are omitted here to avoid confusion:
+# VITE_CLERK_SECRET_KEY=
+# VITE_CLERK_FRONTEND_API=
 
 # Webhook Secret
 CLERK_WEBHOOK_SECRET=your-clerk-webhook-secret

--- a/README.md
+++ b/README.md
@@ -8,12 +8,13 @@ This project is a React application that uses Clerk for authentication and Supab
    ```bash
    npm install
    ```
-2. Copy `.env.example` to `.env` and provide your Supabase credentials along with your Clerk publishable and secret keys:
+2. Copy `.env.example` to `.env` and fill in the required environment variables:
    ```bash
    cp .env.example .env
    # Edit .env with your VITE_SUPABASE_URL, VITE_SUPABASE_ANON_KEY,
-   # VITE_CLERK_PUBLISHABLE_KEY and VITE_CLERK_SECRET_KEY
+   # VITE_CLERK_PUBLISHABLE_KEY and CLERK_WEBHOOK_SECRET
    ```
+   `VITE_CLERK_SECRET_KEY` and `VITE_CLERK_FRONTEND_API` are not used by this project.
 3. Start the development server:
    ```bash
    npm run dev


### PR DESCRIPTION
## Summary
- update `.env.example` to comment out unused Clerk variables
- update README to list only the variables used by the code

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6875bdd4d3dc8333953ee4e901e2e42f