### PR TITLE
Fix Clerk custom domain support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,10 +4,10 @@ VITE_SUPABASE_ANON_KEY=your-supabase-anon-key
 
 # Clerk Configuration
 VITE_CLERK_PUBLISHABLE_KEY=your-clerk-publishable-key
-# The following Clerk variables are not used by this project but may appear in
-# other Clerk examples and are commented out to avoid confusion:
+VITE_CLERK_FRONTEND_API=clerk.your-domain.com
+VITE_CLERK_SIGN_IN_URL=https://accounts.your-domain.com/sign-in
+VITE_CLERK_SIGN_UP_URL=https://accounts.your-domain.com/sign-up
 # VITE_CLERK_SECRET_KEY=
-# VITE_CLERK_FRONTEND_API=
 
 # Webhook Secret
 CLERK_WEBHOOK_SECRET=your-clerk-webhook-secret

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ This project is a React application that uses Clerk for authentication and Supab
    ```bash
    cp .env.example .env
    # Edit .env with your VITE_SUPABASE_URL, VITE_SUPABASE_ANON_KEY,
-   # VITE_CLERK_PUBLISHABLE_KEY and CLERK_WEBHOOK_SECRET
+   # VITE_CLERK_PUBLISHABLE_KEY, VITE_CLERK_FRONTEND_API,
+   # VITE_CLERK_SIGN_IN_URL, VITE_CLERK_SIGN_UP_URL and CLERK_WEBHOOK_SECRET
    ```
-   The app will fail to start without valid Supabase credentials.
-   `VITE_CLERK_SECRET_KEY` and `VITE_CLERK_FRONTEND_API` are not used by this project.
+   The app will fail to start without valid Supabase and Clerk credentials.
 3. Start the development server:
    ```bash
    npm run dev

--- a/src/components/auth/ClerkProviderWithRoutes.jsx
+++ b/src/components/auth/ClerkProviderWithRoutes.jsx
@@ -10,6 +10,9 @@ const ClerkProviderWithRoutes = ({ children }) => {
   
   // Get Clerk configuration from environment variables
   const CLERK_PUBLISHABLE_KEY = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY;
+  const CLERK_FRONTEND_API = import.meta.env.VITE_CLERK_FRONTEND_API;
+  const CLERK_SIGN_IN_URL = import.meta.env.VITE_CLERK_SIGN_IN_URL;
+  const CLERK_SIGN_UP_URL = import.meta.env.VITE_CLERK_SIGN_UP_URL;
 
 
   useEffect(() => {
@@ -53,6 +56,9 @@ const ClerkProviderWithRoutes = ({ children }) => {
   return (
     <ClerkProvider
       publishableKey={CLERK_PUBLISHABLE_KEY}
+      frontendApi={CLERK_FRONTEND_API}
+      signInUrl={CLERK_SIGN_IN_URL}
+      signUpUrl={CLERK_SIGN_UP_URL}
       navigate={(to) => navigate(to)}
       onError={(err) => {
         console.error('Clerk initialization error:', err);

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -6,8 +6,11 @@ import App from './App';
 import './index.css';
 import './App.css';
 
-// Get Clerk publishable key from environment variable
+// Get Clerk configuration from environment variables
 const CLERK_PUBLISHABLE_KEY = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY;
+const CLERK_FRONTEND_API = import.meta.env.VITE_CLERK_FRONTEND_API;
+const CLERK_SIGN_IN_URL = import.meta.env.VITE_CLERK_SIGN_IN_URL;
+const CLERK_SIGN_UP_URL = import.meta.env.VITE_CLERK_SIGN_UP_URL;
 
 if (!CLERK_PUBLISHABLE_KEY) {
   console.error("Missing Clerk publishable key");
@@ -15,8 +18,11 @@ if (!CLERK_PUBLISHABLE_KEY) {
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <ClerkProvider 
+    <ClerkProvider
       publishableKey={CLERK_PUBLISHABLE_KEY}
+      frontendApi={CLERK_FRONTEND_API}
+      signInUrl={CLERK_SIGN_IN_URL}
+      signUpUrl={CLERK_SIGN_UP_URL}
       navigate={(to) => window.location.hash = to.replace('/', '')}
       appearance={{
         variables: {


### PR DESCRIPTION
## Summary
- configure ClerkProvider to use environment variables for custom domains
- document Clerk domain variables in README and `.env.example`

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6875eb32aef083338ebaadb94043a4e4