### PR TITLE
Refactor auth hook and update imports

### DIFF
--- a/src/components/forms/ClientForm.jsx
+++ b/src/components/forms/ClientForm.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useAuth } from '../../contexts/AuthContext';
+import { useAuth } from '../../hooks/useAuth';
 import SafeIcon from '../../common/SafeIcon';
 import * as FiIcons from 'react-icons/fi';
 import supabase from '../../lib/supabase';

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -6,10 +6,10 @@ import logDev from '../utils/logDev';
 const AuthContext = createContext();
 
 // Custom hook for using the auth context
-export const useAuth = () => {
+export const useAuthContext = () => {
   const context = useContext(AuthContext);
   if (!context) {
-    throw new Error('useAuth must be used within an AuthProvider');
+    throw new Error('useAuthContext must be used within an AuthProvider');
   }
   return context;
 };

--- a/src/contexts/CrmContext.jsx
+++ b/src/contexts/CrmContext.jsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext, useState, useEffect } from 'react';
-import { useAuth } from './AuthContext';
+import { useAuthContext } from './AuthContext';
 import supabase from '../lib/supabase';
 import logDev from '../utils/logDev';
 
@@ -25,7 +25,7 @@ export const useCrm = () => {
 };
 
 export const CrmProvider = ({ children }) => {
-  const { user } = useAuth();
+  const { user } = useAuthContext();
   const [clientStatuses, setClientStatuses] = useState({});
   const [statusHistory, setStatusHistory] = useState({});
   const [clientTasks, setClientTasks] = useState({});

--- a/src/contexts/DataContext.jsx
+++ b/src/contexts/DataContext.jsx
@@ -1,6 +1,6 @@
 import React, { createContext, useContext, useState, useEffect } from 'react';
 import supabase from '../lib/supabase';
-import { useAuth } from './AuthContext';
+import { useAuthContext } from './AuthContext';
 import logDev from '../utils/logDev';
 
 const DataContext = createContext();
@@ -15,7 +15,7 @@ export const useData = () => {
 };
 
 export const DataProvider = ({ children }) => {
-  const { user } = useAuth();
+  const { user } = useAuthContext();
   const [clients, setClients] = useState([]);
   const [users, setUsers] = useState([]);
   const [proposals, setProposals] = useState([]);

--- a/src/contexts/FinancialAnalysisContext.jsx
+++ b/src/contexts/FinancialAnalysisContext.jsx
@@ -1,6 +1,6 @@
 import React, { createContext, useContext, useState, useCallback } from 'react';
 import supabase from '../lib/supabase';
-import { useAuth } from './AuthContext';
+import { useAuthContext } from './AuthContext';
 import logDev from '../utils/logDev';
 
 const FinancialAnalysisContext = createContext();
@@ -15,7 +15,7 @@ export const useFinancialAnalysis = () => {
 
 // Export the provider component directly
 export const FinancialAnalysisProvider = ({ children }) => {
-  const { user } = useAuth();
+  const { user } = useAuthContext();
   const [analysis, setAnalysis] = useState(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);

--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -1,5 +1,5 @@
 import { useContext } from 'react';
-import { useAuth as useAuthContext } from '../contexts/AuthContext';
+import { useAuthContext } from '../contexts/AuthContext';
 
 // Define role constants
 const ROLES = {

--- a/src/pages/CRMDashboard.jsx
+++ b/src/pages/CRMDashboard.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import { motion } from 'framer-motion';
-import { useAuth } from '../contexts/AuthContext';
+import { useAuth } from '../hooks/useAuth';
 import { useData } from '../contexts/DataContext';
 import Navbar from '../components/layout/Navbar';
 import ClientStatusStepper, { FUNNEL_STAGES } from '../components/crm/ClientStatusStepper';

--- a/src/pages/ClientFinancialAnalysis.jsx
+++ b/src/pages/ClientFinancialAnalysis.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';
-import { useAuth } from '../contexts/AuthContext';
+import { useAuth } from '../hooks/useAuth';
 import { useFinancialAnalysis } from '../contexts/FinancialAnalysisContext';
 import Navbar from '../components/layout/Navbar';
 import CashflowSection from '../components/financial/CashflowSection';

--- a/src/pages/ClientManagement.jsx
+++ b/src/pages/ClientManagement.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback } from 'react';
 import { Link } from 'react-router-dom';
 import { motion } from 'framer-motion';
-import { useAuth } from '../contexts/AuthContext';
+import { useAuth } from '../hooks/useAuth';
 import { useData } from '../contexts/DataContext';
 import { useCrm } from '../contexts/CrmContext';
 import Navbar from '../components/layout/Navbar';

--- a/src/pages/ClientPortal.jsx
+++ b/src/pages/ClientPortal.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { motion } from 'framer-motion';
-import { useAuth } from '../contexts/AuthContext';
+import { useAuth } from '../hooks/useAuth';
 import { useData } from '../contexts/DataContext';
 import { useFinancialAnalysis } from '../contexts/FinancialAnalysisContext';
 import Navbar from '../components/layout/Navbar';

--- a/src/pages/FinancialAnalysis.jsx
+++ b/src/pages/FinancialAnalysis.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
-import { useAuth } from '../contexts/AuthContext';
+import { useAuth } from '../hooks/useAuth';
 import { useData } from '../contexts/DataContext';
 import { useFinancialAnalysis } from '../contexts/FinancialAnalysisContext';
 import Navbar from '../components/layout/Navbar';

--- a/src/pages/ProfileSettings.jsx
+++ b/src/pages/ProfileSettings.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useAuth } from '../contexts/AuthContext';
+import { useAuth } from '../hooks/useAuth';
 import { useData } from '../contexts/DataContext';
 import { motion } from 'framer-motion';
 import Navbar from '../components/layout/Navbar';

--- a/src/pages/ProjectionsSettings.jsx
+++ b/src/pages/ProjectionsSettings.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
-import { useAuth } from '../contexts/AuthContext';
+import { useAuth } from '../hooks/useAuth';
 import Navbar from '../components/layout/Navbar';
 import StrategiesManager from '../components/admin/StrategiesManager';
 import ProductsManager from '../components/admin/ProductsManager';

--- a/src/pages/ProposalManagement.jsx
+++ b/src/pages/ProposalManagement.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { motion } from 'framer-motion';
-import { useAuth } from '../contexts/AuthContext';
+import { useAuth } from '../hooks/useAuth';
 import { useData } from '../contexts/DataContext';
 import jsPDF from 'jspdf';
 import html2canvas from 'html2canvas';

--- a/src/pages/UserManagement.jsx
+++ b/src/pages/UserManagement.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { motion } from 'framer-motion';
-import { useAuth } from '../contexts/AuthContext';
+import { useAuth } from '../hooks/useAuth';
 import { useData } from '../contexts/DataContext';
 import Navbar from '../components/layout/Navbar';
 import Modal from '../components/ui/Modal';


### PR DESCRIPTION
## Summary
- rename `useAuth` in `AuthContext` to `useAuthContext`
- update `useAuth` helper to import the new hook
- switch pages and components to import from `../hooks/useAuth`
- adjust contexts to call `useAuthContext`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6875fa59bcec83338e75da459e8641d1