### PR TITLE
Protect admin components with role check

### DIFF
--- a/src/components/admin/CarriersManager.jsx
+++ b/src/components/admin/CarriersManager.jsx
@@ -5,12 +5,14 @@ import LoadingSpinner from '../ui/LoadingSpinner';
 import SafeIcon from '../../common/SafeIcon';
 import * as FiIcons from 'react-icons/fi';
 import supabase from '../../lib/supabase';
+import { useAuth } from '../../hooks/useAuth';
 
 const { FiPlus, FiEdit, FiTrash2, FiSave, FiX, FiSearch, FiUpload, FiLink } = FiIcons;
 
 const RATINGS = ['A++', 'A+', 'A', 'A-', 'B++', 'B+', 'B', 'B-', 'C++', 'C+', 'C', 'C-'];
 
 const CarriersManager = () => {
+  const { isAdmin } = useAuth();
   const [carriers, setCarriers] = useState([]);
   const [products, setProducts] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -33,6 +35,7 @@ const CarriersManager = () => {
 
   // Fetch carriers and products
   useEffect(() => {
+    if (!isAdmin) return;
     const fetchData = async () => {
       setLoading(true);
       setError(null);
@@ -334,11 +337,15 @@ const CarriersManager = () => {
     }));
   };
 
-  const filteredCarriers = carriers.filter(carrier => 
+  const filteredCarriers = carriers.filter(carrier =>
     carrier.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
     (carrier.rating && carrier.rating.toLowerCase().includes(searchTerm.toLowerCase())) ||
     (carrier.established && carrier.established.includes(searchTerm))
   );
+
+  if (!isAdmin) {
+    return <p className="text-red-500">You do not have permission to manage carriers.</p>;
+  }
 
   if (loading) {
     return (

--- a/src/components/admin/ProductsManager.jsx
+++ b/src/components/admin/ProductsManager.jsx
@@ -5,6 +5,7 @@ import LoadingSpinner from '../ui/LoadingSpinner';
 import SafeIcon from '../../common/SafeIcon';
 import * as FiIcons from 'react-icons/fi';
 import supabase from '../../lib/supabase';
+import { useAuth } from '../../hooks/useAuth';
 
 const { FiPlus, FiEdit, FiTrash2, FiSave, FiX, FiSearch } = FiIcons;
 
@@ -18,6 +19,7 @@ const PRODUCT_TYPES = [
 ];
 
 const ProductsManager = () => {
+  const { isAdmin } = useAuth();
   const [products, setProducts] = useState([]);
   const [strategies, setStrategies] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -36,6 +38,7 @@ const ProductsManager = () => {
 
   // Fetch products and strategies
   useEffect(() => {
+    if (!isAdmin) return;
     const fetchData = async () => {
       setLoading(true);
       setError(null);
@@ -243,11 +246,15 @@ const ProductsManager = () => {
     }));
   };
 
-  const filteredProducts = products.filter(product => 
+  const filteredProducts = products.filter(product =>
     product.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
     (product.description && product.description.toLowerCase().includes(searchTerm.toLowerCase())) ||
     (product.type && product.type.toLowerCase().includes(searchTerm.toLowerCase()))
   );
+
+  if (!isAdmin) {
+    return <p className="text-red-500">You do not have permission to manage products.</p>;
+  }
 
   const getTypeName = (typeId) => {
     const type = PRODUCT_TYPES.find(t => t.id === typeId);

--- a/src/components/admin/StrategiesManager.jsx
+++ b/src/components/admin/StrategiesManager.jsx
@@ -5,6 +5,7 @@ import LoadingSpinner from '../ui/LoadingSpinner';
 import SafeIcon from '../../common/SafeIcon';
 import * as FiIcons from 'react-icons/fi';
 import supabase from '../../lib/supabase';
+import { useAuth } from '../../hooks/useAuth';
 
 const { FiPlus, FiEdit, FiTrash2, FiSave, FiX, FiSearch } = FiIcons;
 
@@ -19,6 +20,7 @@ const CATEGORIES = [
 ];
 
 const StrategiesManager = () => {
+  const { isAdmin } = useAuth();
   const [strategies, setStrategies] = useState([]);
   const [products, setProducts] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -37,6 +39,7 @@ const StrategiesManager = () => {
 
   // Fetch strategies and products
   useEffect(() => {
+    if (!isAdmin) return;
     const fetchData = async () => {
       setLoading(true);
       setError(null);
@@ -244,10 +247,14 @@ const StrategiesManager = () => {
     }));
   };
 
-  const filteredStrategies = strategies.filter(strategy => 
+  const filteredStrategies = strategies.filter(strategy =>
     strategy.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
     (strategy.description && strategy.description.toLowerCase().includes(searchTerm.toLowerCase()))
   );
+
+  if (!isAdmin) {
+    return <p className="text-red-500">You do not have permission to manage strategies.</p>;
+  }
 
   const getCategoryName = (categoryId) => {
     const category = CATEGORIES.find(cat => cat.id === categoryId);


### PR DESCRIPTION
## Summary
- import `useAuth` in admin managers
- early-return with a permission message when `!isAdmin`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6876008e451c8333906a81a92897cc9e