### PR TITLE
Log admin status for debugging

### DIFF
--- a/src/components/admin/CarriersManager.jsx
+++ b/src/components/admin/CarriersManager.jsx
@@ -6,6 +6,7 @@ import SafeIcon from '../../common/SafeIcon';
 import * as FiIcons from 'react-icons/fi';
 import supabase from '../../lib/supabase';
 import { useAuth } from '../../hooks/useAuth';
+import logDev from '../../utils/logDev';
 
 const { FiPlus, FiEdit, FiTrash2, FiSave, FiX, FiSearch, FiUpload, FiLink } = FiIcons;
 
@@ -13,6 +14,7 @@ const RATINGS = ['A++', 'A+', 'A', 'A-', 'B++', 'B+', 'B', 'B-', 'C++', 'C+', 'C
 
 const CarriersManager = () => {
   const { isAdmin } = useAuth();
+  logDev('CarriersManager isAdmin:', isAdmin);
   const [carriers, setCarriers] = useState([]);
   const [products, setProducts] = useState([]);
   const [loading, setLoading] = useState(true);

--- a/src/components/admin/ProductsManager.jsx
+++ b/src/components/admin/ProductsManager.jsx
@@ -6,6 +6,7 @@ import SafeIcon from '../../common/SafeIcon';
 import * as FiIcons from 'react-icons/fi';
 import supabase from '../../lib/supabase';
 import { useAuth } from '../../hooks/useAuth';
+import logDev from '../../utils/logDev';
 
 const { FiPlus, FiEdit, FiTrash2, FiSave, FiX, FiSearch } = FiIcons;
 
@@ -20,6 +21,7 @@ const PRODUCT_TYPES = [
 
 const ProductsManager = () => {
   const { isAdmin } = useAuth();
+  logDev('ProductsManager isAdmin:', isAdmin);
   const [products, setProducts] = useState([]);
   const [strategies, setStrategies] = useState([]);
   const [loading, setLoading] = useState(true);

--- a/src/components/admin/StrategiesManager.jsx
+++ b/src/components/admin/StrategiesManager.jsx
@@ -6,6 +6,7 @@ import SafeIcon from '../../common/SafeIcon';
 import * as FiIcons from 'react-icons/fi';
 import supabase from '../../lib/supabase';
 import { useAuth } from '../../hooks/useAuth';
+import logDev from '../../utils/logDev';
 
 const { FiPlus, FiEdit, FiTrash2, FiSave, FiX, FiSearch } = FiIcons;
 
@@ -21,6 +22,7 @@ const CATEGORIES = [
 
 const StrategiesManager = () => {
   const { isAdmin } = useAuth();
+  logDev('StrategiesManager isAdmin:', isAdmin);
   const [strategies, setStrategies] = useState([]);
   const [products, setProducts] = useState([]);
   const [loading, setLoading] = useState(true);

--- a/src/pages/ProjectionsSettings.jsx
+++ b/src/pages/ProjectionsSettings.jsx
@@ -10,11 +10,13 @@ import LoadingSpinner from '../components/ui/LoadingSpinner';
 import SafeIcon from '../common/SafeIcon';
 import * as FiIcons from 'react-icons/fi';
 import supabase from '../lib/supabase';
+import logDev from '../utils/logDev';
 
 const { FiSettings, FiShield, FiAlertTriangle } = FiIcons;
 
 const ProjectionsSettings = () => {
   const { user } = useAuth();
+  logDev('ProjectionsSettings user role:', user?.role);
   const navigate = useNavigate();
   const [activeTab, setActiveTab] = useState('strategies');
   const [loading, setLoading] = useState(true);


### PR DESCRIPTION
## Summary
- add logDev to ProjectionsSettings
- output isAdmin inside ProductsManager
- output isAdmin inside CarriersManager
- output isAdmin inside StrategiesManager

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6876ef6dde1883339be7f455599817c5