### PR TITLE
Add role-based menu helper

### DIFF
--- a/src/components/layout/Navbar.jsx
+++ b/src/components/layout/Navbar.jsx
@@ -3,14 +3,15 @@ import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { useClerk } from '@clerk/clerk-react';
 import { useAuth } from '../../hooks/useAuth';
 import logDev from '../../utils/logDev';
+import menuByRole from '../../utils/menuByRole';
 import { motion, AnimatePresence } from 'framer-motion';
 import SafeIcon from '../../common/SafeIcon';
 import * as FiIcons from 'react-icons/fi';
 
-const { FiHome, FiUsers, FiFileText, FiSettings, FiLogOut, FiChevronDown, FiUser } = FiIcons;
+const { FiLogOut, FiChevronDown, FiUser, FiSettings } = FiIcons;
 
 const Navbar = () => {
-  const { user, role, loading, isAdmin, isManager, isClient } = useAuth();
+  const { user, role, loading } = useAuth();
   const { signOut } = useClerk();
   const location = useLocation();
   const navigate = useNavigate();
@@ -22,25 +23,7 @@ const Navbar = () => {
 
   logDev('Navbar role:', role);
 
-  const navItems = [
-    { path: '/dashboard', label: 'Dashboard', icon: FiHome },
-  ];
-
-  if (!isClient) {
-    navItems.push(
-      { path: '/clients', label: 'Clients', icon: FiUsers },
-      { path: '/financial-analysis', label: 'Financial Analysis', icon: FiFileText },
-      { path: '/proposals', label: 'Proposals', icon: FiFileText }
-    );
-  }
-
-  if (isAdmin || isManager) {
-    navItems.push({ path: '/users', label: 'Users', icon: FiUsers });
-  }
-
-  if (isAdmin) {
-    navItems.push({ path: '/projections-settings', label: 'Projections', icon: FiSettings });
-  }
+  const navItems = menuByRole(role);
 
   const handleLogout = async () => {
     await signOut();

--- a/src/utils/menuByRole.js
+++ b/src/utils/menuByRole.js
@@ -1,0 +1,36 @@
+// Utility to generate navigation menu items based on a user's role.
+//
+// Expected role values:
+// - 'admin'
+// - 'manager'
+// - 'financial_professional'
+// - 'client'
+// Any other value will be treated as a basic user.
+
+import * as FiIcons from 'react-icons/fi';
+
+const { FiHome, FiUsers, FiFileText, FiSettings } = FiIcons;
+
+export default function menuByRole(role = '') {
+  const navItems = [
+    { path: '/dashboard', label: 'Dashboard', icon: FiHome }
+  ];
+
+  if (role !== 'client') {
+    navItems.push(
+      { path: '/clients', label: 'Clients', icon: FiUsers },
+      { path: '/financial-analysis', label: 'Financial Analysis', icon: FiFileText },
+      { path: '/proposals', label: 'Proposals', icon: FiFileText }
+    );
+  }
+
+  if (role === 'admin' || role === 'manager') {
+    navItems.push({ path: '/users', label: 'Users', icon: FiUsers });
+  }
+
+  if (role === 'admin') {
+    navItems.push({ path: '/projections-settings', label: 'Projections', icon: FiSettings });
+  }
+
+  return navItems;
+}


### PR DESCRIPTION
## Summary
- create `menuByRole` util to centralize role-based navigation
- simplify `Navbar` logic to use the new helper

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687735e3dc0c83339729afea79350597