### PR TITLE
Fix duplicate fetch bug in financial analysis context

### DIFF
--- a/src/contexts/FinancialAnalysisContext.jsx
+++ b/src/contexts/FinancialAnalysisContext.jsx
@@ -33,6 +33,9 @@ export const FinancialAnalysisProvider = ({ children }) => {
         .select('*')
         .eq('client_id', clientId)
         .eq('created_by', user.id)
+        // Order newest first and limit to a single row to avoid PGRST116 when duplicates exist
+        .order('updated_at', { ascending: false })
+        .limit(1)
         .maybeSingle();
 
       if (fetchError) throw fetchError;


### PR DESCRIPTION
## Summary
- query latest financial analysis for a user and client
- install npm dependencies and run ESLint

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6878038859bc83338ba586bfff3b78e8