### PR TITLE
fix numeric income amounts

### DIFF
--- a/src/components/financial/CashflowSection.jsx
+++ b/src/components/financial/CashflowSection.jsx
@@ -124,10 +124,12 @@ const CashflowSection = ({ incomeSources = [], expenses = [], onIncomeChange, on
     }
 
     const categoryLabel = INCOME_CATEGORIES.find(cat => cat.id === newIncomeSource.category)?.label;
+    const parsedAmount = parseFloat(newIncomeSource.amount);
     const newIncomeSources = [
       ...incomeSources,
       {
         ...newIncomeSource,
+        amount: isNaN(parsedAmount) ? 0 : parsedAmount,
         id: Date.now().toString(),
         description: categoryLabel
       }


### PR DESCRIPTION
## Summary
- parse income amount to number when adding a new income source

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68785632c0c48333b45999d0a815559f