### PR TITLE
Implement optional analysis creation flag

### DIFF
--- a/src/contexts/FinancialAnalysisContext.jsx
+++ b/src/contexts/FinancialAnalysisContext.jsx
@@ -24,7 +24,8 @@ export const FinancialAnalysisProvider = ({ children }) => {
   logDev('FinancialAnalysisProvider rendering, user:', user?.id);
 
   // Load analysis data for a specific client
-  const loadAnalysis = useCallback(async (clientId) => {
+  // If createIfMissing is false, do not insert a new record when none exists
+  const loadAnalysis = useCallback(async (clientId, createIfMissing = true) => {
     try {
       setLoading(true);
       setError(null);
@@ -48,7 +49,7 @@ export const FinancialAnalysisProvider = ({ children }) => {
 
       if (data) {
         setAnalysis(data);
-      } else {
+      } else if (createIfMissing) {
         const newAnalysis = {
           client_id: clientId,
           created_by: user.id,
@@ -81,6 +82,8 @@ export const FinancialAnalysisProvider = ({ children }) => {
 
         if (insertError) throw insertError;
         setAnalysis(inserted || { ...newAnalysis });
+      } else {
+        setAnalysis(null);
       }
     } catch (err) {
       console.error('Error loading analysis:', err);

--- a/src/pages/ClientFinancialAnalysis.jsx
+++ b/src/pages/ClientFinancialAnalysis.jsx
@@ -23,7 +23,7 @@ const ClientFinancialAnalysis = () => {
   // Load the client's financial analysis data
   useEffect(() => {
     if (user?.id) {
-      loadAnalysis(user.id);
+      loadAnalysis(user.id, false);
     }
   }, [user?.id, loadAnalysis]);
 

--- a/src/pages/ClientFinancialReport.jsx
+++ b/src/pages/ClientFinancialReport.jsx
@@ -27,7 +27,7 @@ const ClientFinancialReport = () => {
   // Load financial analysis data
   useEffect(() => {
     if (clientId) {
-      loadAnalysis(clientId);
+      loadAnalysis(clientId, false);
     }
   }, [clientId, loadAnalysis]);
 

--- a/src/pages/ClientPortal.jsx
+++ b/src/pages/ClientPortal.jsx
@@ -31,7 +31,7 @@ const ClientPortal = () => {
   useEffect(() => {
     // Load client's financial analysis data
     if (user?.id) {
-      loadAnalysis(user.id);
+      loadAnalysis(user.id, false);
     }
   }, [user?.id, loadAnalysis]);
 


### PR DESCRIPTION
## Summary
- add `createIfMissing` flag to `loadAnalysis`
- prevent automatic analysis creation on client pages

## Testing
- `npm run lint`
- `npm test` *(fails: TestingLibraryElementError)*

------
https://chatgpt.com/codex/tasks/task_e_68795795e1ac8333b40dd27ad8143928