### PR TITLE
Add fna code migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,13 @@ your user administrative permissions during development:
    { "role": "admin" }
    ```
 3. Save the changes, then sign out and sign back in so the new role is loaded.
+
+## Database Migrations
+
+Supabase schema changes live in `supabase/migrations`. Apply them to a local database with the Supabase CLI:
+
+```bash
+supabase db reset
+```
+
+Migration `003_add_fna_code.sql` adds a `fna_code` text column (unique) along with optional `client_email` and `claimed_at` fields on the `financial_analyses_pf` table.

--- a/supabase/migrations/003_add_fna_code.sql
+++ b/supabase/migrations/003_add_fna_code.sql
@@ -1,0 +1,9 @@
+-- Add unique fna_code and optional claim columns
+ALTER TABLE public.financial_analyses_pf
+ADD COLUMN IF NOT EXISTS fna_code text UNIQUE;
+
+ALTER TABLE public.financial_analyses_pf
+ADD COLUMN IF NOT EXISTS client_email text;
+
+ALTER TABLE public.financial_analyses_pf
+ADD COLUMN IF NOT EXISTS claimed_at timestamptz;


### PR DESCRIPTION
## Summary
- add SQL migration for `fna_code`, `client_email` and `claimed_at`
- document migrations in the README

## Testing
- `npm test` *(fails: TestingLibraryElementError: Unable to find an accessible element with the role "combobox" and name `/select income type/i`)*

------
https://chatgpt.com/codex/tasks/task_e_68795dd3665883339b6a4b2989a6dbfa