### PR TITLE
Adjust DataContext for client scope

### DIFF
--- a/src/pages/ClientPortal.jsx
+++ b/src/pages/ClientPortal.jsx
@@ -29,8 +29,8 @@ const ClientPortal = () => {
   const [claimError, setClaimError] = useState('');
   const [claiming, setClaiming] = useState(false);
 
-  // Get client data (current user's data)
-  const clientData = clients.find(c => c.id === user?.id);
+  // With client scoped data, the first entry is the current user
+  const clientData = clients[0];
 
   useEffect(() => {
     // Load client's financial analysis data


### PR DESCRIPTION
## Summary
- modify DataContext to fetch single client and related data when user role is `client`
- update ClientPortal to rely on client-scoped data

## Testing
- `npm install`
- `npx vitest run` *(fails: TestingLibraryElementError)*

------
https://chatgpt.com/codex/tasks/task_e_68796f24a43c8333ae91ddc731de5304