### PR TITLE
Add effect to show saved FNA code

### DIFF
--- a/src/pages/FinancialAnalysis.jsx
+++ b/src/pages/FinancialAnalysis.jsx
@@ -61,6 +61,13 @@ const FinancialAnalysis = () => {
     }
   }, [selectedClient, loadAnalysis, clientId]);
 
+  // When analysis data loads with an existing share code, populate it
+  useEffect(() => {
+    if (analysis?.fna_code) {
+      setGeneratedCode(analysis.fna_code);
+    }
+  }, [analysis?.fna_code]);
+
   const tabs = [
     { id: 'cashflow', name: 'Cashflow', icon: FiDollarSign },
     { id: 'balance', name: 'Balance Sheet', icon: FiTrendingUp },


### PR DESCRIPTION
## Summary
- ensure generated FNA code shows after returning to FinancialAnalysis page

## Testing
- `npm test --silent`
- `npx vitest run --silent` *(fails: Object.getElementError...)*

------
https://chatgpt.com/codex/tasks/task_e_687a04fe61848333b003355ce1269901