### PR TITLE
Remove embedded CRM fields

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -77,8 +77,8 @@ function App() {
   // If signed in, wrap the app with our providers
   return (
     <AuthProvider>
-      <DataProvider>
-        <CrmProvider>
+      <CrmProvider>
+        <DataProvider>
           <FinancialAnalysisProvider>
             <Routes>
               <Route path="/" element={<Navigate to="/dashboard" replace />} />
@@ -178,8 +178,8 @@ function App() {
               <Route path="*" element={<Navigate to="/dashboard" replace />} />
             </Routes>
           </FinancialAnalysisProvider>
-        </CrmProvider>
-      </DataProvider>
+        </DataProvider>
+      </CrmProvider>
     </AuthProvider>
   );
 }

--- a/src/components/forms/ClientForm.jsx
+++ b/src/components/forms/ClientForm.jsx
@@ -139,23 +139,13 @@ const ClientForm = ({ initialData, onSubmit, onCancel, isEditing }) => {
         };
         dataToSubmit = updateData;
       } else {
-        // For new clients include CRM defaults and creation metadata
+        // For new clients include creation metadata only. CRM data is handled
+        // separately via the CrmContext after the client record is created.
         dataToSubmit = {
           ...baseData,
           advisor_id: user?.id,
           created_by: user?.id,
-          created_at: new Date().toISOString(),
-          crm_status: 'initial_meeting',
-          crm_notes: [],
-          crm_tasks: [],
-          status_history: [{
-            id: Date.now().toString(),
-            from_status: null,
-            to_status: 'initial_meeting',
-            changed_at: new Date().toISOString(),
-            notes: 'Initial status set'
-          }],
-          last_activity: new Date().toISOString()
+          created_at: new Date().toISOString()
         };
       }
 

--- a/supabase/migrations/004_remove_crm_fields.sql
+++ b/supabase/migrations/004_remove_crm_fields.sql
@@ -1,0 +1,6 @@
+-- Remove obsolete CRM columns from clients_pf
+ALTER TABLE public.clients_pf DROP COLUMN IF EXISTS crm_status;
+ALTER TABLE public.clients_pf DROP COLUMN IF EXISTS crm_notes;
+ALTER TABLE public.clients_pf DROP COLUMN IF EXISTS crm_tasks;
+ALTER TABLE public.clients_pf DROP COLUMN IF EXISTS status_history;
+ALTER TABLE public.clients_pf DROP COLUMN IF EXISTS last_activity;


### PR DESCRIPTION
## Summary
- drop obsolete CRM fields from client creation form and data context
- handle CRM setup via `CrmContext.initializeClientCrm`
- rely on `useCrm` for status and task operations
- clean up CRM field usage across pages
- add Supabase migration removing CRM columns
- adjust provider order so `DataContext` can use `CrmContext`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687aa6ad0264833390f045c8aaa1e801