### PR TITLE
Fix CRM task update payload

### DIFF
--- a/src/contexts/CrmContext.jsx
+++ b/src/contexts/CrmContext.jsx
@@ -226,13 +226,19 @@ export const CrmProvider = ({ children }) => {
   const updateClientTask = async (clientId, taskId, updates) => {
     try {
       const timestamp = new Date().toISOString();
-      
+
+      const { taskName, dueDate, ...otherUpdates } = updates || {};
+
+      const payload = {
+        ...otherUpdates,
+        ...(taskName !== undefined && { task_name: taskName }),
+        ...(dueDate !== undefined && { due_date: dueDate }),
+        updated_at: timestamp
+      };
+
       const { data, error } = await supabase
         .from('crm_client_tasks_pf')
-        .update({
-          ...updates,
-          updated_at: timestamp
-        })
+        .update(payload)
         .eq('id', taskId)
         .eq('client_id', clientId)
         .select()


### PR DESCRIPTION
## Summary
- map `taskName` and `dueDate` from updates to Supabase columns

## Testing
- `npm test` *(fails: Unable to find an accessible element with the role "combobox" and name `/select income type/i`)*

------
https://chatgpt.com/codex/tasks/task_e_687ab32a0d288333b69e20c35d967208