### PR TITLE
Implement CRM notes functionality

### DIFF
--- a/src/contexts/__tests__/CrmContextNotes.test.jsx
+++ b/src/contexts/__tests__/CrmContextNotes.test.jsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import CrmProvider, { useCrm } from '../CrmContext';
+import { AuthContext } from '../AuthContext';
+import supabase from '../../lib/supabase';
+import { vi } from 'vitest';
+
+vi.mock('../../lib/supabase', () => ({ default: { from: vi.fn() } }));
+
+const user = { id: 'advisor1' };
+
+function setupSupabase(note, updated) {
+  supabase.from.mockImplementation((table) => {
+    return {
+      select: vi.fn().mockResolvedValue({ data: [] }),
+      eq: vi.fn().mockReturnThis(),
+      insert: vi.fn(() => ({
+        select: () => ({ single: () => Promise.resolve({ data: note }) })
+      })),
+      update: vi.fn(() => ({
+        eq: vi.fn().mockReturnThis(),
+        select: () => ({ single: () => Promise.resolve({ data: updated }) })
+      })),
+      delete: vi.fn(() => ({
+        eq: vi.fn(() => Promise.resolve({ error: null }))
+      })),
+      upsert: vi.fn(() => ({
+        select: () => ({ single: () => Promise.resolve({ data: null }) })
+      }))
+    };
+  });
+}
+
+test('add, update and delete notes', async () => {
+  const note = { id: 'n1', client_id: 'c1', content: 'a', created_at: '2023', updated_at: '2023' };
+  const updated = { ...note, content: 'b', updated_at: '2024' };
+  setupSupabase(note, updated);
+
+  let crm;
+  function Consumer() {
+    crm = useCrm();
+    return null;
+  }
+
+  render(
+    <AuthContext.Provider value={{ user }}>
+      <CrmProvider>
+        <Consumer />
+      </CrmProvider>
+    </AuthContext.Provider>
+  );
+
+  await crm.addClientNote('c1', 'a');
+  expect(crm.getClientNotes('c1')[0].content).toBe('a');
+
+  await crm.updateClientNote('c1', 'n1', 'b');
+  expect(crm.getClientNotes('c1')[0].content).toBe('b');
+
+  await crm.deleteClientNote('c1', 'n1');
+  expect(crm.getClientNotes('c1').length).toBe(0);
+});

--- a/src/pages/__tests__/ClientCRMNotes.test.jsx
+++ b/src/pages/__tests__/ClientCRMNotes.test.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+
+vi.mock('../../contexts/DataContext', () => ({
+  useData: () => ({
+    clients: [{ id: 'c1', name: 'Client One', avatar: '', email: 'c@example.com', phone: '123', createdAt: new Date().toISOString() }]
+  })
+}));
+
+vi.mock('../../contexts/CrmContext', () => ({
+  useCrm: () => ({
+    getClientStatus: () => ({ status: 'initial_meeting' }),
+    getClientHistory: () => [],
+    getClientTasks: () => [],
+    getClientNotes: () => [{ id: 'n1', content: 'note', createdAt: '', updatedAt: '' }],
+    updateClientStatus: vi.fn(),
+    addClientTask: vi.fn(),
+    updateClientTask: vi.fn(),
+    deleteClientTask: vi.fn(),
+    addClientNote: vi.fn(),
+    updateClientNote: vi.fn(),
+    deleteClientNote: vi.fn()
+  })
+}));
+
+import ClientCRM from '../ClientCRM';
+
+ test('renders Notes tab and content', () => {
+  render(
+    <MemoryRouter initialEntries={['/crm/c1']}>
+      <Routes>
+        <Route path="/crm/:clientId" element={<ClientCRM />} />
+      </Routes>
+    </MemoryRouter>
+  );
+
+  const notesTab = screen.getByText('Notes');
+  expect(notesTab).toBeInTheDocument();
+  fireEvent.click(notesTab);
+  expect(screen.getByText('Client Notes')).toBeInTheDocument();
+});

--- a/supabase/migrations/005_add_crm_client_notes.sql
+++ b/supabase/migrations/005_add_crm_client_notes.sql
@@ -1,0 +1,9 @@
+-- Create table for client notes
+CREATE TABLE IF NOT EXISTS public.crm_client_notes_pf (
+  id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+  client_id uuid REFERENCES public.clients_pf(id) ON DELETE CASCADE,
+  advisor_id uuid REFERENCES public.users_pf(id) ON DELETE CASCADE,
+  content text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz
+);


### PR DESCRIPTION
## Summary
- add migration for `crm_client_notes_pf` table
- extend `CrmContext` to load and manage notes
- show notes tab in client CRM page
- provide helpers and tests for notes management

## Testing
- `npm test` *(fails: useAuthContext must be used within an AuthProvider)*

------
https://chatgpt.com/codex/tasks/task_e_687abd0957c8833397567ba310fff217