### PR TITLE
Update env placeholders

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,9 @@ VITE_CLERK_SIGN_UP_URL=https://accounts.your-domain.com/sign-up
 
 # Webhook Secret
 CLERK_WEBHOOK_SECRET=your-clerk-webhook-secret
+
+# Clerk JWT verification key
+CLERK_JWT_KEY=
+
+# Supabase service role key
+SUPABASE_SERVICE_ROLE_KEY=

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ This project is a React application that uses Clerk for authentication and Supab
    cp .env.example .env
    # Edit .env with your VITE_SUPABASE_URL, VITE_SUPABASE_ANON_KEY,
    # VITE_CLERK_PUBLISHABLE_KEY, VITE_CLERK_FRONTEND_API,
-   # VITE_CLERK_SIGN_IN_URL, VITE_CLERK_SIGN_UP_URL and CLERK_WEBHOOK_SECRET
+   # VITE_CLERK_SIGN_IN_URL, VITE_CLERK_SIGN_UP_URL,
+   # CLERK_WEBHOOK_SECRET, CLERK_JWT_KEY and SUPABASE_SERVICE_ROLE_KEY
    ```
    The app will fail to start without valid Supabase and Clerk credentials. The
    Supabase URL and key must be provided via environment variables, otherwise the


### PR DESCRIPTION
## Summary
- extend `.env.example` with missing placeholders for Clerk and Supabase
- document the new variables in the setup instructions

## Testing
- `npm test` *(fails: useAuthContext must be used within an AuthProvider)*

------
https://chatgpt.com/codex/tasks/task_e_687b0d8ae2b88333a0c637fc9766f2b3