### PR TITLE
Add auth token helper for Supabase client

### DIFF
--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -8,12 +8,17 @@ if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
   throw new Error('Missing Supabase environment variables');
 }
 
-// Create a Supabase client
+// Create a Supabase client. The anon key is only used for the initial
+// connection; the authenticated token is set separately after login.
 const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
   auth: {
     persistSession: true,
     autoRefreshToken: true
   }
 });
+
+export function setAuthToken(token) {
+  supabase.auth.setAuth(token);
+}
 
 export default supabase;


### PR DESCRIPTION
## Summary
- provide `setAuthToken` helper to update the auth token on the Supabase client
- clarify default export comment

## Testing
- `npm test` *(fails: useAuthContext must be used within an AuthProvider)*

------
https://chatgpt.com/codex/tasks/task_e_687b0ed1e2188333b73c342b13b1caa1