### PR TITLE
Use admin Supabase client in webhook

### DIFF
--- a/api/clerk-webhook.js
+++ b/api/clerk-webhook.js
@@ -1,5 +1,11 @@
 import { Webhook } from 'svix';
-import supabase from '../src/lib/supabase';
+import { createClient } from '@supabase/supabase-js';
+
+// Initialize an admin Supabase client using service role credentials
+const supabase = createClient(
+  process.env.VITE_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
 
 export default async function handler(req, res) {
   // Webhook expects CLERK_WEBHOOK_SECRET in environment variables


### PR DESCRIPTION
## Summary
- initialize an admin Supabase client in `api/clerk-webhook.js`

## Testing
- `npm test --silent` *(fails: useAuthContext must be used within an AuthProvider)*

------
https://chatgpt.com/codex/tasks/task_e_687b137dd26c8333ac0871901fd97ffd