### PR TITLE
Rename note field and update tests

### DIFF
--- a/src/components/crm/ClientNotes.jsx
+++ b/src/components/crm/ClientNotes.jsx
@@ -15,7 +15,7 @@ const ClientNotes = ({ notes = [], onNotesChange, clientName }) => {
     if (newNote.trim()) {
       const note = {
         id: Date.now().toString(),
-        content: newNote.trim(),
+        note: newNote.trim(),
         createdAt: new Date().toISOString(),
         type: 'note'
       };
@@ -27,16 +27,16 @@ const ClientNotes = ({ notes = [], onNotesChange, clientName }) => {
 
   const handleEditNote = (noteId) => {
     const note = notes.find(n => n.id === noteId);
-    setEditNote(note.content);
+    setEditNote(note.note);
     setEditingNoteId(noteId);
   };
 
   const handleSaveEdit = () => {
     if (editNote.trim()) {
-      const updatedNotes = notes.map(note =>
-        note.id === editingNoteId
-          ? { ...note, content: editNote.trim(), updatedAt: new Date().toISOString() }
-          : note
+      const updatedNotes = notes.map(noteItem =>
+        noteItem.id === editingNoteId
+          ? { ...noteItem, note: editNote.trim(), updatedAt: new Date().toISOString() }
+          : noteItem
       );
       onNotesChange(updatedNotes);
       setEditingNoteId(null);
@@ -176,7 +176,7 @@ const ClientNotes = ({ notes = [], onNotesChange, clientName }) => {
                 </div>
               ) : (
                 <div className="text-gray-700 whitespace-pre-wrap">
-                  {note.content}
+                  {note.note}
                 </div>
               )}
             </motion.div>

--- a/src/contexts/CrmContext.jsx
+++ b/src/contexts/CrmContext.jsx
@@ -107,14 +107,14 @@ export const CrmProvider = ({ children }) => {
         if (notesError) throw notesError;
 
         const notes = {};
-        (notesData || []).forEach(note => {
-          if (!notes[note.client_id]) notes[note.client_id] = [];
-          notes[note.client_id].push({
-            id: note.id,
-            clientId: note.client_id,
-            content: note.content,
-            createdAt: note.created_at,
-            updatedAt: note.updated_at
+        (notesData || []).forEach(noteRow => {
+          if (!notes[noteRow.client_id]) notes[noteRow.client_id] = [];
+          notes[noteRow.client_id].push({
+            id: noteRow.id,
+            clientId: noteRow.client_id,
+            note: noteRow.note,
+            createdAt: noteRow.created_at,
+            updatedAt: noteRow.updated_at
           });
         });
 
@@ -338,7 +338,7 @@ export const CrmProvider = ({ children }) => {
   };
 
   // Add note
-  const addClientNote = async (clientId, content) => {
+  const addClientNote = async (clientId, noteText) => {
     try {
       const timestamp = new Date().toISOString();
 
@@ -346,7 +346,7 @@ export const CrmProvider = ({ children }) => {
         .from('crm_client_notes_pf')
         .insert({
           client_id: clientId,
-          content,
+          note: noteText,
           created_at: timestamp,
           updated_at: timestamp,
           advisor_id: user.id
@@ -362,7 +362,7 @@ export const CrmProvider = ({ children }) => {
           {
             id: note.id,
             clientId: note.client_id,
-            content: note.content,
+            note: note.note,
             createdAt: note.created_at,
             updatedAt: note.updated_at
           },
@@ -378,13 +378,13 @@ export const CrmProvider = ({ children }) => {
   };
 
   // Update note
-  const updateClientNote = async (clientId, noteId, content) => {
+  const updateClientNote = async (clientId, noteId, noteText) => {
     try {
       const timestamp = new Date().toISOString();
 
       const { data, error } = await supabase
         .from('crm_client_notes_pf')
-        .update({ content, updated_at: timestamp })
+        .update({ note: noteText, updated_at: timestamp })
         .eq('id', noteId)
         .eq('client_id', clientId)
         .select()
@@ -394,16 +394,16 @@ export const CrmProvider = ({ children }) => {
 
       setClientNotes(prev => ({
         ...prev,
-        [clientId]: (prev[clientId] || []).map(note =>
-          note.id === noteId
+        [clientId]: (prev[clientId] || []).map(noteItem =>
+          noteItem.id === noteId
             ? {
                 id: data.id,
                 clientId: data.client_id,
-                content: data.content,
+                note: data.note,
                 createdAt: data.created_at,
                 updatedAt: data.updated_at
               }
-            : note
+            : noteItem
         )
       }));
 

--- a/src/pages/ClientCRM.jsx
+++ b/src/pages/ClientCRM.jsx
@@ -81,9 +81,9 @@ const ClientCRM = () => {
 
     for (const note of updatedNotes) {
       if (!existingMap[note.id]) {
-        await addClientNote(clientId, note.content);
-      } else if (existingMap[note.id].content !== note.content) {
-        await updateClientNote(clientId, note.id, note.content);
+        await addClientNote(clientId, note.note);
+      } else if (existingMap[note.id].note !== note.note) {
+        await updateClientNote(clientId, note.id, note.note);
       }
     }
 

--- a/src/pages/__tests__/ClientCRMNotes.test.jsx
+++ b/src/pages/__tests__/ClientCRMNotes.test.jsx
@@ -4,6 +4,11 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { vi } from 'vitest';
 
+// Mock Navbar to avoid AuthProvider dependency
+vi.mock('../../components/layout/Navbar', () => ({
+  default: () => <div />
+}));
+
 vi.mock('../../contexts/DataContext', () => ({
   useData: () => ({
     clients: [{ id: 'c1', name: 'Client One', avatar: '', email: 'c@example.com', phone: '123', createdAt: new Date().toISOString() }]
@@ -15,7 +20,7 @@ vi.mock('../../contexts/CrmContext', () => ({
     getClientStatus: () => ({ status: 'initial_meeting' }),
     getClientHistory: () => [],
     getClientTasks: () => [],
-    getClientNotes: () => [{ id: 'n1', content: 'note', createdAt: '', updatedAt: '' }],
+    getClientNotes: () => [{ id: 'n1', note: 'note', createdAt: '', updatedAt: '' }],
     updateClientStatus: vi.fn(),
     addClientTask: vi.fn(),
     updateClientTask: vi.fn(),


### PR DESCRIPTION
## Summary
- use `note` instead of `content` in CRM note logic
- update CRM context and components for new field name
- adjust tests for renamed property and mock Navbar

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687b336cf63083339f6b0bd05695f4e7