### PR TITLE
Document service role key usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ Row level security (**RLS**) is enabled across all user data tables to ensure re
    application will throw an error during startup.
 
   * `CLERK_JWT_KEY` can be found in the **Clerk dashboard** under **API Keys → JWT Verification Key**. Copy the entire PEM string into your `.env` file. This key allows the backend to validate Clerk-issued JWTs.
-  * `SUPABASE_SERVICE_ROLE_KEY` lives in the **Supabase dashboard** under **Settings → API → Service Role**. Keep this key private as it bypasses RLS and is required for service-role operations such as migrations and seeding data.
+  * `SUPABASE_SERVICE_ROLE_KEY` lives in the **Supabase dashboard** under **Settings → API → Service Role**. Keep this key private as it bypasses RLS and is required for service-role operations such as migrations, seeding data, and other backend tasks that need unrestricted access.
+
+    Any API route or server-side function that must bypass RLS—like the Clerk webhook—should create its own Supabase client using this key.
 
 Both variables are required for JWT authentication and service-role database access.
 3. Start the development server:


### PR DESCRIPTION
## Summary
- document that API endpoints needing RLS bypass should use the SUPABASE_SERVICE_ROLE_KEY

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_687d943e0b78833386c5388ff1a096a6