### PR TITLE
Handle Supabase sign‑in errors

### DIFF
--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -19,9 +19,18 @@ const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
 
 export async function setAuthToken(token) {
   if (token) {
-    await supabase.auth.signInWithIdToken({ provider: 'clerk', token });
-  } else {
-    await supabase.auth.signOut();
+    const { data, error } = await supabase.auth.signInWithIdToken({ provider: 'clerk', token });
+    if (error) {
+      console.error('Error signing in with ID token:', error);
+      throw error;
+    }
+    return data;
+  }
+
+  const { error } = await supabase.auth.signOut();
+  if (error) {
+    console.error('Error signing out:', error);
+    throw error;
   }
 }
 


### PR DESCRIPTION
## Summary
- check result of `signInWithIdToken`
- surface sign-in failures in AuthContext
- protect sign-out with error handling

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687dc7e8fc7c8333800accd843b35a6f