### PR TITLE
Integrate Clerk auth with Supabase

### DIFF
--- a/src/components/admin/CarriersManager.jsx
+++ b/src/components/admin/CarriersManager.jsx
@@ -4,7 +4,7 @@ import Modal from '../ui/Modal';
 import LoadingSpinner from '../ui/LoadingSpinner';
 import SafeIcon from '../../common/SafeIcon';
 import * as FiIcons from 'react-icons/fi';
-import supabase from '../../lib/supabase';
+import useSupabaseClientWithClerk from '../../hooks/useSupabaseClientWithClerk';
 import { useAuth } from '../../hooks/useAuth';
 import logDev from '../../utils/logDev';
 
@@ -15,6 +15,7 @@ const RATINGS = ['A++', 'A+', 'A', 'A-', 'B++', 'B+', 'B', 'B-', 'C++', 'C+', 'C
 const CarriersManager = () => {
   const { isAdmin } = useAuth();
   logDev('CarriersManager isAdmin:', isAdmin);
+  const supabase = useSupabaseClientWithClerk();
   const [carriers, setCarriers] = useState([]);
   const [products, setProducts] = useState([]);
   const [loading, setLoading] = useState(true);

--- a/src/components/admin/ProductsManager.jsx
+++ b/src/components/admin/ProductsManager.jsx
@@ -4,7 +4,7 @@ import Modal from '../ui/Modal';
 import LoadingSpinner from '../ui/LoadingSpinner';
 import SafeIcon from '../../common/SafeIcon';
 import * as FiIcons from 'react-icons/fi';
-import supabase from '../../lib/supabase';
+import useSupabaseClientWithClerk from '../../hooks/useSupabaseClientWithClerk';
 import { useAuth } from '../../hooks/useAuth';
 import logDev from '../../utils/logDev';
 
@@ -22,6 +22,7 @@ const PRODUCT_TYPES = [
 const ProductsManager = () => {
   const { isAdmin } = useAuth();
   logDev('ProductsManager isAdmin:', isAdmin);
+  const supabase = useSupabaseClientWithClerk();
   const [products, setProducts] = useState([]);
   const [strategies, setStrategies] = useState([]);
   const [loading, setLoading] = useState(true);

--- a/src/components/admin/StrategiesManager.jsx
+++ b/src/components/admin/StrategiesManager.jsx
@@ -4,7 +4,7 @@ import Modal from '../ui/Modal';
 import LoadingSpinner from '../ui/LoadingSpinner';
 import SafeIcon from '../../common/SafeIcon';
 import * as FiIcons from 'react-icons/fi';
-import supabase from '../../lib/supabase';
+import useSupabaseClientWithClerk from '../../hooks/useSupabaseClientWithClerk';
 import { useAuth } from '../../hooks/useAuth';
 import logDev from '../../utils/logDev';
 
@@ -23,6 +23,7 @@ const CATEGORIES = [
 const StrategiesManager = () => {
   const { isAdmin } = useAuth();
   logDev('StrategiesManager isAdmin:', isAdmin);
+  const supabase = useSupabaseClientWithClerk();
   const [strategies, setStrategies] = useState([]);
   const [products, setProducts] = useState([]);
   const [loading, setLoading] = useState(true);

--- a/src/components/proposals/CarrierSelector.jsx
+++ b/src/components/proposals/CarrierSelector.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import SafeIcon from '../../common/SafeIcon';
 import * as FiIcons from 'react-icons/fi';
-import supabase from '../../lib/supabase';
+import useSupabaseClientWithClerk from '../../hooks/useSupabaseClientWithClerk';
 import LoadingSpinner from '../ui/LoadingSpinner';
 
 const { FiCheck, FiAlertTriangle } = FiIcons;
@@ -10,6 +10,7 @@ const CarrierSelector = ({ selectedCarrier, onCarrierChange, selectedProduct }) 
   const [carriers, setCarriers] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  const supabase = useSupabaseClientWithClerk();
 
   // Fetch carriers that offer the selected product
   useEffect(() => {

--- a/src/components/proposals/StrategySelector.jsx
+++ b/src/components/proposals/StrategySelector.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import SafeIcon from '../../common/SafeIcon';
 import * as FiIcons from 'react-icons/fi';
-import supabase from '../../lib/supabase';
+import useSupabaseClientWithClerk from '../../hooks/useSupabaseClientWithClerk';
 import LoadingSpinner from '../ui/LoadingSpinner';
 
 const { FiShield, FiTrendingUp, FiDollarSign, FiHeart, FiUsers, FiAward, FiAlertTriangle } = FiIcons;
@@ -11,6 +11,7 @@ const StrategySelector = ({ selectedStrategy, onStrategyChange, selectedProduct,
   const [availableProducts, setAvailableProducts] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  const supabase = useSupabaseClientWithClerk();
 
   // Fetch strategies from Supabase
   useEffect(() => {

--- a/src/contexts/CrmContext.jsx
+++ b/src/contexts/CrmContext.jsx
@@ -1,6 +1,6 @@
 import React, { createContext, useContext, useState, useEffect } from 'react';
 import { useAuthContext } from './AuthContext';
-import supabase from '../lib/supabase';
+import useSupabaseClientWithClerk from '../hooks/useSupabaseClientWithClerk';
 import logDev from '../utils/logDev';
 
 // Status stages
@@ -26,6 +26,7 @@ export const useCrm = () => {
 
 export const CrmProvider = ({ children }) => {
   const { user } = useAuthContext();
+  const supabase = useSupabaseClientWithClerk();
   const [clientStatuses, setClientStatuses] = useState({});
   const [statusHistory, setStatusHistory] = useState({});
   const [clientTasks, setClientTasks] = useState({});

--- a/src/contexts/DataContext.jsx
+++ b/src/contexts/DataContext.jsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext, useState, useEffect } from 'react';
-import supabase from '../lib/supabase';
+import useSupabaseClientWithClerk from '../hooks/useSupabaseClientWithClerk';
 import { useAuthContext } from './AuthContext';
 import { useCrm } from './CrmContext';
 import logDev from '../utils/logDev';
@@ -18,6 +18,7 @@ export const useData = () => {
 export const DataProvider = ({ children }) => {
   const { user } = useAuthContext();
   const { initializeClientCrm } = useCrm();
+  const supabase = useSupabaseClientWithClerk();
   const [clients, setClients] = useState([]);
   const [users, setUsers] = useState([]);
   const [proposals, setProposals] = useState([]);

--- a/src/contexts/FinancialAnalysisContext.jsx
+++ b/src/contexts/FinancialAnalysisContext.jsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext, useState, useCallback } from 'react';
-import supabase from '../lib/supabase';
+import useSupabaseClientWithClerk from '../hooks/useSupabaseClientWithClerk';
 import { useAuthContext } from './AuthContext';
 import logDev from '../utils/logDev';
 
@@ -16,6 +16,7 @@ export const useFinancialAnalysis = () => {
 // Export the provider component directly
 export const FinancialAnalysisProvider = ({ children }) => {
   const { user } = useAuthContext();
+  const supabase = useSupabaseClientWithClerk();
   const [analysis, setAnalysis] = useState(null);
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);

--- a/src/hooks/useSupabaseClientWithClerk.js
+++ b/src/hooks/useSupabaseClientWithClerk.js
@@ -1,0 +1,41 @@
+import { useMemo } from 'react';
+import { useAuth } from '@clerk/clerk-react';
+import supabase from '../lib/supabase';
+
+let patched = false;
+
+export default function useSupabaseClientWithClerk() {
+  let getToken;
+  try {
+    ({ getToken } = useAuth());
+  } catch {
+    getToken = async () => null;
+  }
+
+  return useMemo(() => {
+    if (!supabase.auth || !supabase.auth.getSession) {
+      return supabase;
+    }
+
+    if (!patched) {
+      const originalGetSession = supabase.auth.getSession.bind(supabase.auth);
+      supabase.auth.getSession = async (...args) => {
+        const token = await getToken({ template: 'supabase' });
+        if (!token) {
+          await supabase.auth.signOut();
+          return { data: { session: null }, error: null };
+        }
+        const { error } = await supabase.auth.setSession({
+          access_token: token,
+          refresh_token: token
+        });
+        if (error) {
+          console.error('Error setting Supabase session:', error);
+        }
+        return originalGetSession(...args);
+      };
+      patched = true;
+    }
+    return supabase;
+  }, [getToken]);
+}

--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -8,30 +8,12 @@ if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
   throw new Error('Missing Supabase environment variables');
 }
 
-// Create a Supabase client. The anon key is only used for the initial
-// connection; the authenticated token is set separately after login.
+// Create a Supabase client. Authentication will be handled by Clerk.
 const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
   auth: {
-    persistSession: true,
-    autoRefreshToken: true
+    persistSession: false,
+    autoRefreshToken: false
   }
 });
-
-export async function setAuthToken(token) {
-  if (token) {
-    const { data, error } = await supabase.auth.signInWithIdToken({ provider: 'clerk', token });
-    if (error) {
-      console.error('Error signing in with ID token:', error);
-      throw error;
-    }
-    return data;
-  }
-
-  const { error } = await supabase.auth.signOut();
-  if (error) {
-    console.error('Error signing out:', error);
-    throw error;
-  }
-}
 
 export default supabase;

--- a/src/pages/ClientPortal.jsx
+++ b/src/pages/ClientPortal.jsx
@@ -10,13 +10,14 @@ import ClientForm from '../components/forms/ClientForm';
 import ProposalPDF from '../components/proposals/ProposalPDF';
 import LoadingSpinner from '../components/ui/LoadingSpinner';
 import SafeIcon from '../common/SafeIcon';
-import supabase from '../lib/supabase';
+import useSupabaseClientWithClerk from '../hooks/useSupabaseClientWithClerk';
 import * as FiIcons from 'react-icons/fi';
 
 const { FiUser, FiEdit, FiBarChart2, FiActivity, FiFileText, FiMail, FiPhone, FiMapPin, FiCalendar, FiUsers, FiBriefcase, FiShield, FiStar, FiBuilding, FiDollarSign, FiTrendingUp, FiSettings } = FiIcons;
 
 const ClientPortal = () => {
   const { user } = useAuth();
+  const supabase = useSupabaseClientWithClerk();
   const { clients, proposals, users, updateClient } = useData();
   const { analysis, loadAnalysis, loading: analysisLoading } = useFinancialAnalysis();
   

--- a/src/pages/FinancialAnalysis.jsx
+++ b/src/pages/FinancialAnalysis.jsx
@@ -14,7 +14,7 @@ import FinancialPlanningSection from '../components/financial/FinancialPlanningS
 import FinancialGoalsSection from '../components/financial/FinancialGoalsSection';
 import LoadingSpinner from '../components/ui/LoadingSpinner';
 import SafeIcon from '../common/SafeIcon';
-import supabase from '../lib/supabase';
+import useSupabaseClientWithClerk from '../hooks/useSupabaseClientWithClerk';
 import logDev from '../utils/logDev';
 import * as FiIcons from 'react-icons/fi';
 
@@ -24,6 +24,7 @@ const FinancialAnalysis = () => {
   const { clientId } = useParams(); // Optional - if accessed from client details
   const navigate = useNavigate();
   const { user } = useAuth();
+  const supabase = useSupabaseClientWithClerk();
   const { clients } = useData();
   const { analysis, loadAnalysis, saveAnalysis, setAnalysis, loading } = useFinancialAnalysis();
   const [activeTab, setActiveTab] = useState('cashflow');

--- a/src/pages/ProjectionsSettings.jsx
+++ b/src/pages/ProjectionsSettings.jsx
@@ -9,13 +9,14 @@ import CarriersManager from '../components/admin/CarriersManager';
 import LoadingSpinner from '../components/ui/LoadingSpinner';
 import SafeIcon from '../common/SafeIcon';
 import * as FiIcons from 'react-icons/fi';
-import supabase from '../lib/supabase';
+import useSupabaseClientWithClerk from '../hooks/useSupabaseClientWithClerk';
 import logDev from '../utils/logDev';
 
 const { FiSettings, FiShield, FiAlertTriangle } = FiIcons;
 
 const ProjectionsSettings = () => {
   const { user } = useAuth();
+  const supabase = useSupabaseClientWithClerk();
   logDev('ProjectionsSettings user role:', user?.role);
   const navigate = useNavigate();
   const [activeTab, setActiveTab] = useState('strategies');

--- a/src/pages/ProposalManagement.jsx
+++ b/src/pages/ProposalManagement.jsx
@@ -14,7 +14,7 @@ import ProductConfiguration from '../components/proposals/ProductConfiguration';
 import ProposalPDF from '../components/proposals/ProposalPDF';
 import SafeIcon from '../common/SafeIcon';
 import * as FiIcons from 'react-icons/fi';
-import supabase from '../lib/supabase';
+import useSupabaseClientWithClerk from '../hooks/useSupabaseClientWithClerk';
 
 const { FiPlus, FiSearch, FiEdit, FiTrash2, FiEye, FiSend, FiCalendar, FiUser, FiDownload, FiPrinter } = FiIcons;
 
@@ -144,6 +144,7 @@ const DEFAULT_CARRIERS = [
 
 const ProposalManagement = () => {
   const { user } = useAuth();
+  const supabase = useSupabaseClientWithClerk();
   const { proposals, clients, users, addProposal, updateProposal, deleteProposal } = useData();
   const [isAddModalOpen, setIsAddModalOpen] = useState(false);
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);


### PR DESCRIPTION
## Summary
- centralize Supabase client creation using Clerk tokens
- expose new `useSupabaseClientWithClerk` hook for auth-aware Supabase access
- refactor contexts and pages to use the new hook
- remove old token helpers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687dfed79f288333aa9ccd903accdaf0