### PR TITLE
Update addClient to use Supabase user

### DIFF
--- a/src/contexts/DataContext.jsx
+++ b/src/contexts/DataContext.jsx
@@ -126,13 +126,16 @@ export const DataProvider = ({ children }) => {
         ...cleanClient
       } = client;
 
+      const { data: { user: supaUser }, error: userErr } = await supabase.auth.getUser();
+      if (userErr) throw userErr;
+
       const { data, error } = await supabase
         .from('clients_pf')
-        .insert({ ...cleanClient, advisor_id: user.supabaseId })
+        .insert({ ...cleanClient, advisor_id: supaUser.id })
         .select();
       if (error) throw error;
 
-      const newClient = data && data.length > 0 ? data[0] : { ...client, advisor_id: user.supabaseId };
+      const newClient = data && data.length > 0 ? data[0] : { ...client, advisor_id: supaUser.id };
       setClients(prev => [...prev, newClient]);
 
       // Initialize CRM records for the newly created client


### PR DESCRIPTION
## Summary
- fetch current Supabase user inside `addClient`
- use the Supabase user id when inserting a client
- include advisor id in fallback client object

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68804e4a27808333bef372d569c7bdde