### PR TITLE
Switch to Supabase AuthProvider

### DIFF
--- a/src/lib/supabaseClient.js
+++ b/src/lib/supabaseClient.js
@@ -1,80 +1,21 @@
-// src/lib/supabaseClient.js - FIXED VERSION
 import { createClient } from '@supabase/supabase-js';
-import { useAuth } from '@clerk/clerk-react';
-import { useState, useEffect } from 'react';
+import { useMemo } from 'react';
 
 const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL;
 const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
-// Create a single Supabase client instance
-let supabaseInstance = null;
+let supabaseInstance;
+
+const getClient = () => {
+  if (!supabaseInstance) {
+    supabaseInstance = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+  }
+  return supabaseInstance;
+};
 
 export function useSupabaseWithClerk() {
-  const { getToken, isLoaded } = useAuth();
-  const [supabaseClient, setSupabaseClient] = useState(null);
-
-  useEffect(() => {
-    const initializeClient = async () => {
-      if (!isLoaded) return;
-
-      try {
-        const token = await getToken({ template: 'supabase' });
-        
-        // Create client only once with custom auth handling
-        if (!supabaseInstance) {
-          supabaseInstance = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
-            global: {
-              headers: {
-                Authorization: token ? `Bearer ${token}` : undefined,
-              },
-            },
-            auth: {
-              persistSession: false, // Let Clerk handle session persistence
-            },
-          });
-        } else {
-          // Update the authorization header for existing client
-          supabaseInstance.rest.headers.Authorization = token ? `Bearer ${token}` : undefined;
-        }
-        
-        setSupabaseClient(supabaseInstance);
-      } catch (error) {
-        console.error('Error initializing Supabase client:', error);
-      }
-    };
-
-    initializeClient();
-  }, [getToken, isLoaded]);
-
-  return supabaseClient; // Return the client directly
+  return useMemo(() => getClient(), []);
 }
 
-// Alternative: Keep your current approach but fix the usage
-export function useSupabaseWithClerkAsync() {
-  const { getToken } = useAuth();
-  
-  const getSupabaseClient = async () => {
-    const token = await getToken({ template: 'supabase' });
-    
-    // Create client only once with custom auth handling
-    if (!supabaseInstance) {
-      supabaseInstance = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
-        global: {
-          headers: {
-            Authorization: token ? `Bearer ${token}` : undefined,
-          },
-        },
-        auth: {
-          persistSession: false, // Let Clerk handle session persistence
-        },
-      });
-    } else {
-      // Update the authorization header for existing client
-      supabaseInstance.rest.headers.Authorization = token ? `Bearer ${token}` : undefined;
-    }
-    
-    return supabaseInstance;
-  };
-  
-  return { getSupabaseClient };
-}
+export const useSupabase = useSupabaseWithClerk;
+export const supabase = getClient();

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,44 +1,17 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { HashRouter } from 'react-router-dom';
-import { ClerkProvider } from '@clerk/clerk-react';
+import { AuthProvider } from './contexts/AuthContext';
 import App from './App';
 import './index.css';
 import './App.css';
 
-// Get Clerk configuration from environment variables
-const CLERK_PUBLISHABLE_KEY = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY;
-const CLERK_FRONTEND_API = import.meta.env.VITE_CLERK_FRONTEND_API;
-const CLERK_SIGN_IN_URL = import.meta.env.VITE_CLERK_SIGN_IN_URL;
-const CLERK_SIGN_UP_URL = import.meta.env.VITE_CLERK_SIGN_UP_URL;
-
-if (!CLERK_PUBLISHABLE_KEY) {
-  console.error("Missing Clerk publishable key");
-}
-
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <ClerkProvider
-      publishableKey={CLERK_PUBLISHABLE_KEY}
-      frontendApi={CLERK_FRONTEND_API}
-      signInUrl={CLERK_SIGN_IN_URL}
-      signUpUrl={CLERK_SIGN_UP_URL}
-      navigate={(to) => window.location.hash = to.replace('/', '')}
-      appearance={{
-        variables: {
-          colorPrimary: '#0284c7',
-          borderRadius: '0.5rem',
-        },
-        elements: {
-          rootBox: 'w-full',
-          card: 'w-full',
-          formButtonPrimary: 'bg-primary-600 hover:bg-primary-700 text-white'
-        }
-      }}
-    >
+    <AuthProvider>
       <HashRouter>
         <App />
       </HashRouter>
-    </ClerkProvider>
+    </AuthProvider>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- replace ClerkProvider setup with new Supabase-based AuthProvider
- implement Supabase AuthProvider context
- simplify Supabase client hook

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68806c2e9d6c8333b0e50e1a48c63337