### PR TITLE
Replace Clerk auth with context hook

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import logDev from './utils/logDev';
 import { Routes, Route, Navigate } from 'react-router-dom';
-import { useAuth as useClerkAuth } from '@clerk/clerk-react';
+import useAuth from './hooks/useAuth';
 import LoadingSpinner from './components/ui/LoadingSpinner';
 
 // Import providers
@@ -11,8 +11,8 @@ import { CrmProvider } from './contexts/CrmContext';
 import { FinancialAnalysisProvider } from './contexts/FinancialAnalysisContext';
 
 // Import pages
-import ClerkSignIn from './pages/ClerkSignIn';
-import ClerkSignUp from './pages/ClerkSignUp';
+import Login from './pages/Login';
+import Signup from './pages/Signup';
 import Dashboard from './pages/Dashboard';
 import CRMDashboard from './pages/CRMDashboard';
 import ClientCRM from './pages/ClientCRM';
@@ -29,20 +29,20 @@ import ProjectionsSettings from './pages/ProjectionsSettings';
 import PrivateRoute from './components/auth/PrivateRoute';
 
 function App() {
-  const { isLoaded, isSignedIn } = useClerkAuth();
+  const { loading, isSignedIn } = useAuth();
   const [authError, setAuthError] = useState(null);
 
   useEffect(() => {
-    if (isLoaded || authError) return;
+    if (!loading || authError) return;
     const timer = setTimeout(() => {
-      if (!isLoaded) {
+      if (loading) {
         setAuthError('Authentication failed to initialize. Please check your environment variables or domain configuration.');
       }
     }, 10000);
     return () => clearTimeout(timer);
-  }, [isLoaded, authError]);
+  }, [loading, authError]);
   
-  logDev('App rendering, authentication state:', { isLoaded, isSignedIn });
+  logDev('App rendering, authentication state:', { loading, isSignedIn });
 
   if (authError) {
     return (
@@ -55,7 +55,7 @@ function App() {
     );
   }
   
-  if (!isLoaded) {
+  if (loading) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-gray-50">
         <LoadingSpinner size="lg" />
@@ -67,9 +67,9 @@ function App() {
   if (!isSignedIn) {
     return (
       <Routes>
-        <Route path="/sign-in" element={<ClerkSignIn />} />
-        <Route path="/sign-up" element={<ClerkSignUp />} />
-        <Route path="*" element={<Navigate to="/sign-in" replace />} />
+        <Route path="/login" element={<Login />} />
+        <Route path="/signup" element={<Signup />} />
+        <Route path="*" element={<Navigate to="/login" replace />} />
       </Routes>
     );
   }
@@ -173,8 +173,8 @@ function App() {
                   </PrivateRoute>
                 }
               />
-              <Route path="/sign-in" element={<Navigate to="/dashboard" replace />} />
-              <Route path="/sign-up" element={<Navigate to="/dashboard" replace />} />
+              <Route path="/login" element={<Navigate to="/dashboard" replace />} />
+              <Route path="/signup" element={<Navigate to="/dashboard" replace />} />
               <Route path="*" element={<Navigate to="/dashboard" replace />} />
             </Routes>
           </FinancialAnalysisProvider>

--- a/src/components/auth/PrivateRoute.jsx
+++ b/src/components/auth/PrivateRoute.jsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import { Navigate, useLocation } from 'react-router-dom';
-import { useUser } from '@clerk/clerk-react';
+import useAuth from '../../hooks/useAuth';
 import LoadingSpinner from '../ui/LoadingSpinner';
 
 const PrivateRoute = ({ children, allowedRoles = [], requireAuth = true }) => {
-  const { user, isLoaded, isSignedIn } = useUser();
+  const { user, loading, isSignedIn } = useAuth();
   const location = useLocation();
 
   // Show loading spinner while Clerk loads
-  if (!isLoaded) {
+  if (loading) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-gray-50">
         <LoadingSpinner size="lg" />
@@ -18,7 +18,7 @@ const PrivateRoute = ({ children, allowedRoles = [], requireAuth = true }) => {
 
   // If auth is required and user isn't signed in, redirect to login
   if (requireAuth && !isSignedIn) {
-    return <Navigate to="/sign-in" state={{ from: location }} replace />;
+    return <Navigate to="/login" state={{ from: location }} replace />;
   }
 
   // If we have role restrictions

--- a/src/components/auth/ProtectedRoute.jsx
+++ b/src/components/auth/ProtectedRoute.jsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Navigate } from 'react-router-dom';
-import { useUser } from '@clerk/clerk-react';
+import useAuth from '../../hooks/useAuth';
 import LoadingSpinner from '../ui/LoadingSpinner';
 
 const ProtectedRoute = ({ children, allowedRoles = [] }) => {
-  const { user, isLoaded } = useUser();
+  const { user, loading, isSignedIn } = useAuth();
 
-  if (!isLoaded) {
+  if (loading) {
     return (
       <div className="min-h-screen bg-gray-50 flex items-center justify-center">
         <LoadingSpinner size="lg" />
@@ -14,8 +14,8 @@ const ProtectedRoute = ({ children, allowedRoles = [] }) => {
     );
   }
 
-  if (!user) {
-    return <Navigate to="/sign-in" replace />;
+  if (!isSignedIn) {
+    return <Navigate to="/login" replace />;
   }
 
   // Check if user has required role

--- a/src/components/layout/Navbar.jsx
+++ b/src/components/layout/Navbar.jsx
@@ -27,7 +27,7 @@ const Navbar = () => {
 
   const handleLogout = async () => {
     await signOut();
-    navigate('/sign-in');
+    navigate('/login');
   };
 
   return (

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -185,7 +185,7 @@ const Login = () => {
             <div className="text-center">
               <p className="text-sm text-gray-600">
                 Don't have an account?{' '}
-                <Link to="/sign-up" className="font-medium text-primary-600 hover:text-primary-700">
+                <Link to="/signup" className="font-medium text-primary-600 hover:text-primary-700">
                   Sign up{' '}
                   <SafeIcon icon={FiArrowRight} className="ml-1 inline-block w-3 h-3" />
                 </Link>


### PR DESCRIPTION
## Summary
- switch `useClerkAuth` usage to the custom `useAuth` hook
- use new login/signup routes instead of Clerk pages
- update protected route components to rely on the new hook
- redirect logout to `/login`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68806c36f96c833385908432eb2e7085