### PR TITLE
Remove Clerk usage from Supabase client

### DIFF
--- a/src/components/admin/CarriersManager.jsx
+++ b/src/components/admin/CarriersManager.jsx
@@ -4,7 +4,7 @@ import Modal from '../ui/Modal';
 import LoadingSpinner from '../ui/LoadingSpinner';
 import SafeIcon from '../../common/SafeIcon';
 import * as FiIcons from 'react-icons/fi';
-import { useSupabaseWithClerk } from '../../lib/supabaseClient';
+import { useSupabase } from '../../lib/supabaseClient';
 import { useAuth } from '../../hooks/useAuth';
 import logDev from '../../utils/logDev';
 
@@ -15,7 +15,7 @@ const RATINGS = ['A++', 'A+', 'A', 'A-', 'B++', 'B+', 'B', 'B-', 'C++', 'C+', 'C
 const CarriersManager = () => {
   const { isAdmin } = useAuth();
   logDev('CarriersManager isAdmin:', isAdmin);
-  const supabase = useSupabaseWithClerk();
+  const supabase = useSupabase();
   const [carriers, setCarriers] = useState([]);
   const [products, setProducts] = useState([]);
   const [loading, setLoading] = useState(true);

--- a/src/components/admin/ProductsManager.jsx
+++ b/src/components/admin/ProductsManager.jsx
@@ -4,7 +4,7 @@ import Modal from '../ui/Modal';
 import LoadingSpinner from '../ui/LoadingSpinner';
 import SafeIcon from '../../common/SafeIcon';
 import * as FiIcons from 'react-icons/fi';
-import { useSupabaseWithClerk } from '../../lib/supabaseClient';
+import { useSupabase } from '../../lib/supabaseClient';
 import { useAuth } from '../../hooks/useAuth';
 import logDev from '../../utils/logDev';
 
@@ -22,7 +22,7 @@ const PRODUCT_TYPES = [
 const ProductsManager = () => {
   const { isAdmin } = useAuth();
   logDev('ProductsManager isAdmin:', isAdmin);
-  const supabase = useSupabaseWithClerk();
+  const supabase = useSupabase();
   const [products, setProducts] = useState([]);
   const [strategies, setStrategies] = useState([]);
   const [loading, setLoading] = useState(true);

--- a/src/components/admin/StrategiesManager.jsx
+++ b/src/components/admin/StrategiesManager.jsx
@@ -4,7 +4,7 @@ import Modal from '../ui/Modal';
 import LoadingSpinner from '../ui/LoadingSpinner';
 import SafeIcon from '../../common/SafeIcon';
 import * as FiIcons from 'react-icons/fi';
-import { useSupabaseWithClerk } from '../../lib/supabaseClient';
+import { useSupabase } from '../../lib/supabaseClient';
 import { useAuth } from '../../hooks/useAuth';
 import logDev from '../../utils/logDev';
 
@@ -23,7 +23,7 @@ const CATEGORIES = [
 const StrategiesManager = () => {
   const { isAdmin } = useAuth();
   logDev('StrategiesManager isAdmin:', isAdmin);
-  const supabase = useSupabaseWithClerk();
+  const supabase = useSupabase();
   const [strategies, setStrategies] = useState([]);
   const [products, setProducts] = useState([]);
   const [loading, setLoading] = useState(true);

--- a/src/components/proposals/CarrierSelector.jsx
+++ b/src/components/proposals/CarrierSelector.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import SafeIcon from '../../common/SafeIcon';
 import * as FiIcons from 'react-icons/fi';
-import { useSupabaseWithClerk } from '../../lib/supabaseClient';
+import { useSupabase } from '../../lib/supabaseClient';
 import LoadingSpinner from '../ui/LoadingSpinner';
 
 const { FiCheck, FiAlertTriangle } = FiIcons;
@@ -10,7 +10,7 @@ const CarrierSelector = ({ selectedCarrier, onCarrierChange, selectedProduct }) 
   const [carriers, setCarriers] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
-  const supabase = useSupabaseWithClerk();
+  const supabase = useSupabase();
 
   // Fetch carriers that offer the selected product
   useEffect(() => {

--- a/src/components/proposals/StrategySelector.jsx
+++ b/src/components/proposals/StrategySelector.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import SafeIcon from '../../common/SafeIcon';
 import * as FiIcons from 'react-icons/fi';
-import { useSupabaseWithClerk } from '../../lib/supabaseClient';
+import { useSupabase } from '../../lib/supabaseClient';
 import LoadingSpinner from '../ui/LoadingSpinner';
 
 const { FiShield, FiTrendingUp, FiDollarSign, FiHeart, FiUsers, FiAward, FiAlertTriangle } = FiIcons;
@@ -11,7 +11,7 @@ const StrategySelector = ({ selectedStrategy, onStrategyChange, selectedProduct,
   const [availableProducts, setAvailableProducts] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
-  const supabase = useSupabaseWithClerk();
+  const supabase = useSupabase();
 
   // Fetch strategies from Supabase
   useEffect(() => {

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -1,7 +1,7 @@
 import React, { createContext, useContext, useState, useEffect } from 'react';
 import { useUser, useAuth } from '@clerk/clerk-react';
 import logDev from '../utils/logDev';
-import { useSupabaseWithClerk } from '../lib/supabaseClient';
+import { useSupabase } from '../lib/supabaseClient';
 
 // Create the auth context
 const AuthContext = createContext();
@@ -18,7 +18,7 @@ export const useAuthContext = () => {
 export const AuthProvider = ({ children }) => {
   const { user: clerkUser } = useUser();
   const { isLoaded, isSignedIn, getToken } = useAuth(); // Add getToken here
-  const supabase = useSupabaseWithClerk();
+  const supabase = useSupabase();
   const [user, setUser] = useState(null);
   const [loading, setLoading] = useState(true);
 

--- a/src/contexts/CrmContext.jsx
+++ b/src/contexts/CrmContext.jsx
@@ -1,6 +1,6 @@
 import React, { createContext, useContext, useState, useEffect } from 'react';
 import { useAuthContext } from './AuthContext';
-import { useSupabaseWithClerk } from '../lib/supabaseClient';
+import { useSupabase } from '../lib/supabaseClient';
 import logDev from '../utils/logDev';
 
 // Status stages
@@ -26,7 +26,7 @@ export const useCrm = () => {
 
 export const CrmProvider = ({ children }) => {
   const { user } = useAuthContext();
-  const supabase = useSupabaseWithClerk();
+  const supabase = useSupabase();
   const [clientStatuses, setClientStatuses] = useState({});
   const [statusHistory, setStatusHistory] = useState({});
   const [clientTasks, setClientTasks] = useState({});

--- a/src/contexts/DataContext.jsx
+++ b/src/contexts/DataContext.jsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext, useState, useEffect } from 'react';
-import { useSupabaseWithClerk } from '../lib/supabaseClient';
+import { useSupabase } from '../lib/supabaseClient';
 import { useAuthContext } from './AuthContext';
 import { useCrm } from './CrmContext';
 import logDev from '../utils/logDev';
@@ -18,7 +18,7 @@ export const useData = () => {
 export const DataProvider = ({ children }) => {
   const { user } = useAuthContext();
   const { initializeClientCrm } = useCrm();
-  const supabase = useSupabaseWithClerk();
+  const supabase = useSupabase();
   const [clients, setClients] = useState([]);
   const [users, setUsers] = useState([]);
   const [proposals, setProposals] = useState([]);

--- a/src/contexts/FinancialAnalysisContext.jsx
+++ b/src/contexts/FinancialAnalysisContext.jsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext, useState, useCallback } from 'react';
-import { useSupabaseWithClerk } from '../lib/supabaseClient';
+import { useSupabase } from '../lib/supabaseClient';
 import { useAuthContext } from './AuthContext';
 import logDev from '../utils/logDev';
 
@@ -16,7 +16,7 @@ export const useFinancialAnalysis = () => {
 // Export the provider component directly
 export const FinancialAnalysisProvider = ({ children }) => {
   const { user } = useAuthContext();
-  const supabase = useSupabaseWithClerk();
+  const supabase = useSupabase();
   const [analysis, setAnalysis] = useState(null);
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);

--- a/src/contexts/__tests__/CrmContextNotes.test.jsx
+++ b/src/contexts/__tests__/CrmContextNotes.test.jsx
@@ -13,7 +13,7 @@ import { vi } from 'vitest';
 
 vi.mock('../../lib/supabaseClient', () => ({
   supabase: { from: vi.fn() },
-  useSupabaseWithClerk: () => supabase
+  useSupabase: () => supabase
 }));
 
 const user = { id: 'advisor1' };

--- a/src/hooks/useSupabaseClientWithClerk.js
+++ b/src/hooks/useSupabaseClientWithClerk.js
@@ -1,1 +1,1 @@
-export { useSupabaseWithClerk as default } from '../lib/supabaseClient';
+export { useSupabase as default } from '../lib/supabaseClient';

--- a/src/lib/supabaseClient.js
+++ b/src/lib/supabaseClient.js
@@ -1,80 +1,10 @@
-// src/lib/supabaseClient.js - FIXED VERSION
 import { createClient } from '@supabase/supabase-js';
-import { useAuth } from '@clerk/clerk-react';
-import { useState, useEffect } from 'react';
 
 const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL;
 const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
-// Create a single Supabase client instance
-let supabaseInstance = null;
+export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
 
-export function useSupabaseWithClerk() {
-  const { getToken, isLoaded } = useAuth();
-  const [supabaseClient, setSupabaseClient] = useState(null);
-
-  useEffect(() => {
-    const initializeClient = async () => {
-      if (!isLoaded) return;
-
-      try {
-        const token = await getToken({ template: 'supabase' });
-        
-        // Create client only once with custom auth handling
-        if (!supabaseInstance) {
-          supabaseInstance = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
-            global: {
-              headers: {
-                Authorization: token ? `Bearer ${token}` : undefined,
-              },
-            },
-            auth: {
-              persistSession: false, // Let Clerk handle session persistence
-            },
-          });
-        } else {
-          // Update the authorization header for existing client
-          supabaseInstance.rest.headers.Authorization = token ? `Bearer ${token}` : undefined;
-        }
-        
-        setSupabaseClient(supabaseInstance);
-      } catch (error) {
-        console.error('Error initializing Supabase client:', error);
-      }
-    };
-
-    initializeClient();
-  }, [getToken, isLoaded]);
-
-  return supabaseClient; // Return the client directly
-}
-
-// Alternative: Keep your current approach but fix the usage
-export function useSupabaseWithClerkAsync() {
-  const { getToken } = useAuth();
-  
-  const getSupabaseClient = async () => {
-    const token = await getToken({ template: 'supabase' });
-    
-    // Create client only once with custom auth handling
-    if (!supabaseInstance) {
-      supabaseInstance = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
-        global: {
-          headers: {
-            Authorization: token ? `Bearer ${token}` : undefined,
-          },
-        },
-        auth: {
-          persistSession: false, // Let Clerk handle session persistence
-        },
-      });
-    } else {
-      // Update the authorization header for existing client
-      supabaseInstance.rest.headers.Authorization = token ? `Bearer ${token}` : undefined;
-    }
-    
-    return supabaseInstance;
-  };
-  
-  return { getSupabaseClient };
+export function useSupabase() {
+  return supabase;
 }

--- a/src/pages/ClientPortal.jsx
+++ b/src/pages/ClientPortal.jsx
@@ -10,14 +10,14 @@ import ClientForm from '../components/forms/ClientForm';
 import ProposalPDF from '../components/proposals/ProposalPDF';
 import LoadingSpinner from '../components/ui/LoadingSpinner';
 import SafeIcon from '../common/SafeIcon';
-import { useSupabaseWithClerk } from '../lib/supabaseClient';
+import { useSupabase } from '../lib/supabaseClient';
 import * as FiIcons from 'react-icons/fi';
 
 const { FiUser, FiEdit, FiBarChart2, FiActivity, FiFileText, FiMail, FiPhone, FiMapPin, FiCalendar, FiUsers, FiBriefcase, FiShield, FiStar, FiBuilding, FiDollarSign, FiTrendingUp, FiSettings } = FiIcons;
 
 const ClientPortal = () => {
   const { user } = useAuth();
-  const supabase = useSupabaseWithClerk();
+  const supabase = useSupabase();
   const { clients, proposals, users, updateClient } = useData();
   const { analysis, loadAnalysis, loading: analysisLoading } = useFinancialAnalysis();
   

--- a/src/pages/FinancialAnalysis.jsx
+++ b/src/pages/FinancialAnalysis.jsx
@@ -14,7 +14,7 @@ import FinancialPlanningSection from '../components/financial/FinancialPlanningS
 import FinancialGoalsSection from '../components/financial/FinancialGoalsSection';
 import LoadingSpinner from '../components/ui/LoadingSpinner';
 import SafeIcon from '../common/SafeIcon';
-import { useSupabaseWithClerk } from '../lib/supabaseClient';
+import { useSupabase } from '../lib/supabaseClient';
 import logDev from '../utils/logDev';
 import * as FiIcons from 'react-icons/fi';
 
@@ -24,7 +24,7 @@ const FinancialAnalysis = () => {
   const { clientId } = useParams(); // Optional - if accessed from client details
   const navigate = useNavigate();
   const { user } = useAuth();
-  const supabase = useSupabaseWithClerk();
+  const supabase = useSupabase();
   const { clients } = useData();
   const { analysis, loadAnalysis, saveAnalysis, setAnalysis, loading } = useFinancialAnalysis();
   const [activeTab, setActiveTab] = useState('cashflow');

--- a/src/pages/ProjectionsSettings.jsx
+++ b/src/pages/ProjectionsSettings.jsx
@@ -9,14 +9,14 @@ import CarriersManager from '../components/admin/CarriersManager';
 import LoadingSpinner from '../components/ui/LoadingSpinner';
 import SafeIcon from '../common/SafeIcon';
 import * as FiIcons from 'react-icons/fi';
-import { useSupabaseWithClerk } from '../lib/supabaseClient';
+import { useSupabase } from '../lib/supabaseClient';
 import logDev from '../utils/logDev';
 
 const { FiSettings, FiShield, FiAlertTriangle } = FiIcons;
 
 const ProjectionsSettings = () => {
   const { user } = useAuth();
-  const supabase = useSupabaseWithClerk();
+  const supabase = useSupabase();
   logDev('ProjectionsSettings user role:', user?.role);
   const navigate = useNavigate();
   const [activeTab, setActiveTab] = useState('strategies');

--- a/src/pages/ProposalManagement.jsx
+++ b/src/pages/ProposalManagement.jsx
@@ -14,7 +14,7 @@ import ProductConfiguration from '../components/proposals/ProductConfiguration';
 import ProposalPDF from '../components/proposals/ProposalPDF';
 import SafeIcon from '../common/SafeIcon';
 import * as FiIcons from 'react-icons/fi';
-import { useSupabaseWithClerk } from '../lib/supabaseClient';
+import { useSupabase } from '../lib/supabaseClient';
 
 const { FiPlus, FiSearch, FiEdit, FiTrash2, FiEye, FiSend, FiCalendar, FiUser, FiDownload, FiPrinter } = FiIcons;
 
@@ -144,7 +144,7 @@ const DEFAULT_CARRIERS = [
 
 const ProposalManagement = () => {
   const { user } = useAuth();
-  const supabase = useSupabaseWithClerk();
+  const supabase = useSupabase();
   const { proposals, clients, users, addProposal, updateProposal, deleteProposal } = useData();
   const [isAddModalOpen, setIsAddModalOpen] = useState(false);
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);


### PR DESCRIPTION
## Summary
- simplify `supabaseClient.js` to a plain Supabase client
- rename hook to `useSupabase`
- update exports to use the new hook
- replace all references to `useSupabaseWithClerk`

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68806c4d704c83338aaa2dd5cc5c8030