### PR TITLE
Update contexts to new Supabase hook

### DIFF
--- a/src/components/admin/CarriersManager.jsx
+++ b/src/components/admin/CarriersManager.jsx
@@ -4,7 +4,7 @@ import Modal from '../ui/Modal';
 import LoadingSpinner from '../ui/LoadingSpinner';
 import SafeIcon from '../../common/SafeIcon';
 import * as FiIcons from 'react-icons/fi';
-import { useSupabaseWithClerk } from '../../lib/supabaseClient';
+import { useSupabase } from '../../lib/supabaseClient';
 import { useAuth } from '../../hooks/useAuth';
 import logDev from '../../utils/logDev';
 
@@ -15,7 +15,7 @@ const RATINGS = ['A++', 'A+', 'A', 'A-', 'B++', 'B+', 'B', 'B-', 'C++', 'C+', 'C
 const CarriersManager = () => {
   const { isAdmin } = useAuth();
   logDev('CarriersManager isAdmin:', isAdmin);
-  const supabase = useSupabaseWithClerk();
+  const supabase = useSupabase();
   const [carriers, setCarriers] = useState([]);
   const [products, setProducts] = useState([]);
   const [loading, setLoading] = useState(true);

--- a/src/components/admin/ProductsManager.jsx
+++ b/src/components/admin/ProductsManager.jsx
@@ -4,7 +4,7 @@ import Modal from '../ui/Modal';
 import LoadingSpinner from '../ui/LoadingSpinner';
 import SafeIcon from '../../common/SafeIcon';
 import * as FiIcons from 'react-icons/fi';
-import { useSupabaseWithClerk } from '../../lib/supabaseClient';
+import { useSupabase } from '../../lib/supabaseClient';
 import { useAuth } from '../../hooks/useAuth';
 import logDev from '../../utils/logDev';
 
@@ -22,7 +22,7 @@ const PRODUCT_TYPES = [
 const ProductsManager = () => {
   const { isAdmin } = useAuth();
   logDev('ProductsManager isAdmin:', isAdmin);
-  const supabase = useSupabaseWithClerk();
+  const supabase = useSupabase();
   const [products, setProducts] = useState([]);
   const [strategies, setStrategies] = useState([]);
   const [loading, setLoading] = useState(true);

--- a/src/components/admin/StrategiesManager.jsx
+++ b/src/components/admin/StrategiesManager.jsx
@@ -4,7 +4,7 @@ import Modal from '../ui/Modal';
 import LoadingSpinner from '../ui/LoadingSpinner';
 import SafeIcon from '../../common/SafeIcon';
 import * as FiIcons from 'react-icons/fi';
-import { useSupabaseWithClerk } from '../../lib/supabaseClient';
+import { useSupabase } from '../../lib/supabaseClient';
 import { useAuth } from '../../hooks/useAuth';
 import logDev from '../../utils/logDev';
 
@@ -23,7 +23,7 @@ const CATEGORIES = [
 const StrategiesManager = () => {
   const { isAdmin } = useAuth();
   logDev('StrategiesManager isAdmin:', isAdmin);
-  const supabase = useSupabaseWithClerk();
+  const supabase = useSupabase();
   const [strategies, setStrategies] = useState([]);
   const [products, setProducts] = useState([]);
   const [loading, setLoading] = useState(true);

--- a/src/components/proposals/CarrierSelector.jsx
+++ b/src/components/proposals/CarrierSelector.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import SafeIcon from '../../common/SafeIcon';
 import * as FiIcons from 'react-icons/fi';
-import { useSupabaseWithClerk } from '../../lib/supabaseClient';
+import { useSupabase } from '../../lib/supabaseClient';
 import LoadingSpinner from '../ui/LoadingSpinner';
 
 const { FiCheck, FiAlertTriangle } = FiIcons;
@@ -10,7 +10,7 @@ const CarrierSelector = ({ selectedCarrier, onCarrierChange, selectedProduct }) 
   const [carriers, setCarriers] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
-  const supabase = useSupabaseWithClerk();
+  const supabase = useSupabase();
 
   // Fetch carriers that offer the selected product
   useEffect(() => {

--- a/src/components/proposals/StrategySelector.jsx
+++ b/src/components/proposals/StrategySelector.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import SafeIcon from '../../common/SafeIcon';
 import * as FiIcons from 'react-icons/fi';
-import { useSupabaseWithClerk } from '../../lib/supabaseClient';
+import { useSupabase } from '../../lib/supabaseClient';
 import LoadingSpinner from '../ui/LoadingSpinner';
 
 const { FiShield, FiTrendingUp, FiDollarSign, FiHeart, FiUsers, FiAward, FiAlertTriangle } = FiIcons;
@@ -11,7 +11,7 @@ const StrategySelector = ({ selectedStrategy, onStrategyChange, selectedProduct,
   const [availableProducts, setAvailableProducts] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
-  const supabase = useSupabaseWithClerk();
+  const supabase = useSupabase();
 
   // Fetch strategies from Supabase
   useEffect(() => {

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -1,7 +1,7 @@
 import React, { createContext, useContext, useState, useEffect } from 'react';
 import { useUser, useAuth } from '@clerk/clerk-react';
 import logDev from '../utils/logDev';
-import { useSupabaseWithClerk } from '../lib/supabaseClient';
+import { useSupabase } from '../lib/supabaseClient';
 
 // Create the auth context
 const AuthContext = createContext();
@@ -18,7 +18,7 @@ export const useAuthContext = () => {
 export const AuthProvider = ({ children }) => {
   const { user: clerkUser } = useUser();
   const { isLoaded, isSignedIn, getToken } = useAuth(); // Add getToken here
-  const supabase = useSupabaseWithClerk();
+  const supabase = useSupabase();
   const [user, setUser] = useState(null);
   const [loading, setLoading] = useState(true);
 

--- a/src/contexts/CrmContext.jsx
+++ b/src/contexts/CrmContext.jsx
@@ -1,6 +1,6 @@
 import React, { createContext, useContext, useState, useEffect } from 'react';
 import { useAuthContext } from './AuthContext';
-import { useSupabaseWithClerk } from '../lib/supabaseClient';
+import { useSupabase } from '../lib/supabaseClient';
 import logDev from '../utils/logDev';
 
 // Status stages
@@ -26,7 +26,7 @@ export const useCrm = () => {
 
 export const CrmProvider = ({ children }) => {
   const { user } = useAuthContext();
-  const supabase = useSupabaseWithClerk();
+  const supabase = useSupabase();
   const [clientStatuses, setClientStatuses] = useState({});
   const [statusHistory, setStatusHistory] = useState({});
   const [clientTasks, setClientTasks] = useState({});
@@ -46,7 +46,7 @@ export const CrmProvider = ({ children }) => {
         const { data: statusData, error: statusError } = await supabase
           .from('crm_client_statuses_pf')
           .select('*')
-          .eq('advisor_id', user.supabaseId);
+          .eq('advisor_id', user.id);
 
         if (statusError) throw statusError;
 
@@ -62,7 +62,7 @@ export const CrmProvider = ({ children }) => {
         const { data: historyData, error: historyError } = await supabase
           .from('crm_status_history_pf')
           .select('*')
-          .eq('advisor_id', user.supabaseId);
+          .eq('advisor_id', user.id);
 
         if (historyError) throw historyError;
 
@@ -81,7 +81,7 @@ export const CrmProvider = ({ children }) => {
         const { data: tasksData, error: tasksError } = await supabase
           .from('crm_client_tasks_pf')
           .select('*')
-          .eq('advisor_id', user.supabaseId);
+          .eq('advisor_id', user.id);
 
         if (tasksError) throw tasksError;
 
@@ -103,7 +103,7 @@ export const CrmProvider = ({ children }) => {
         const { data: notesData, error: notesError } = await supabase
           .from('crm_client_notes_pf')
           .select('*')
-          .eq('advisor_id', user.supabaseId);
+          .eq('advisor_id', user.id);
 
         if (notesError) throw notesError;
 
@@ -147,7 +147,7 @@ export const CrmProvider = ({ children }) => {
           client_id: clientId,
           status: newStatus,
           updated_at: timestamp,
-          advisor_id: user.supabaseId
+          advisor_id: user.id
         })
         .select()
         .single();
@@ -170,7 +170,7 @@ export const CrmProvider = ({ children }) => {
           status: newStatus,
           notes,
           created_at: timestamp,
-          advisor_id: user.supabaseId
+          advisor_id: user.id
         })
         .select()
         .single();
@@ -213,7 +213,7 @@ export const CrmProvider = ({ children }) => {
           completed: false,
           created_at: timestamp,
           updated_at: timestamp,
-          advisor_id: user.supabaseId
+          advisor_id: user.id
         })
         .select()
         .single();
@@ -350,7 +350,7 @@ export const CrmProvider = ({ children }) => {
           note: noteText,
           created_at: timestamp,
           updated_at: timestamp,
-          advisor_id: user.supabaseId
+          advisor_id: user.id
         })
         .select()
         .single();
@@ -449,7 +449,7 @@ export const CrmProvider = ({ children }) => {
           client_id: clientId,
           status: 'initial_meeting',
           updated_at: timestamp,
-          advisor_id: user.supabaseId
+          advisor_id: user.id
         })
         .select()
         .single();
@@ -463,7 +463,7 @@ export const CrmProvider = ({ children }) => {
           status: 'initial_meeting',
           notes: 'Initial status set',
           created_at: timestamp,
-          advisor_id: user.supabaseId
+          advisor_id: user.id
         })
         .select()
         .single();

--- a/src/contexts/DataContext.jsx
+++ b/src/contexts/DataContext.jsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext, useState, useEffect } from 'react';
-import { useSupabaseWithClerk } from '../lib/supabaseClient';
+import { useSupabase } from '../lib/supabaseClient';
 import { useAuthContext } from './AuthContext';
 import { useCrm } from './CrmContext';
 import logDev from '../utils/logDev';
@@ -18,7 +18,7 @@ export const useData = () => {
 export const DataProvider = ({ children }) => {
   const { user } = useAuthContext();
   const { initializeClientCrm } = useCrm();
-  const supabase = useSupabaseWithClerk();
+  const supabase = useSupabase();
   const [clients, setClients] = useState([]);
   const [users, setUsers] = useState([]);
   const [proposals, setProposals] = useState([]);
@@ -80,19 +80,19 @@ export const DataProvider = ({ children }) => {
           const { data: cData, error: cError } = await supabase
             .from('clients_pf')
             .select('*')
-            .eq('advisor_id', user.supabaseId);
+            .eq('advisor_id', user.id);
         if (cError) throw cError;
 
           const { data: uData, error: uError } = await supabase
             .from('users_pf')
             .select('*')
-            .eq('advisor_id', user.supabaseId);
+            .eq('advisor_id', user.id);
         if (uError) throw uError;
 
           const { data: pData, error: pError } = await supabase
             .from('projections_pf')
             .select('*')
-            .eq('advisor_id', user.supabaseId);
+            .eq('advisor_id', user.id);
         if (pError) throw pError;
 
         clientsData = cData || [];
@@ -217,11 +217,11 @@ export const DataProvider = ({ children }) => {
     try {
       const { data, error } = await supabase
         .from('users_pf')
-        .insert({ ...userData, advisor_id: user.supabaseId })
+        .insert({ ...userData, advisor_id: user.id })
         .select();
       if (error) throw error;
 
-      const newUser = data && data.length > 0 ? data[0] : { ...userData, advisor_id: user.supabaseId };
+      const newUser = data && data.length > 0 ? data[0] : { ...userData, advisor_id: user.id };
       setUsers(prev => [...prev, newUser]);
       return newUser;
     } catch (error) {
@@ -280,11 +280,11 @@ export const DataProvider = ({ children }) => {
     try {
       const { data, error } = await supabase
         .from('projections_pf')
-        .insert({ ...proposal, advisor_id: user.supabaseId })
+        .insert({ ...proposal, advisor_id: user.id })
         .select();
       if (error) throw error;
 
-      const newProposal = data && data.length > 0 ? data[0] : { ...proposal, advisor_id: user.supabaseId };
+      const newProposal = data && data.length > 0 ? data[0] : { ...proposal, advisor_id: user.id };
       setProposals(prev => [...prev, newProposal]);
       return newProposal;
     } catch (error) {

--- a/src/contexts/FinancialAnalysisContext.jsx
+++ b/src/contexts/FinancialAnalysisContext.jsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext, useState, useCallback } from 'react';
-import { useSupabaseWithClerk } from '../lib/supabaseClient';
+import { useSupabase } from '../lib/supabaseClient';
 import { useAuthContext } from './AuthContext';
 import logDev from '../utils/logDev';
 
@@ -16,7 +16,7 @@ export const useFinancialAnalysis = () => {
 // Export the provider component directly
 export const FinancialAnalysisProvider = ({ children }) => {
   const { user } = useAuthContext();
-  const supabase = useSupabaseWithClerk();
+  const supabase = useSupabase();
   const [analysis, setAnalysis] = useState(null);
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);

--- a/src/contexts/__tests__/CrmContextNotes.test.jsx
+++ b/src/contexts/__tests__/CrmContextNotes.test.jsx
@@ -13,7 +13,7 @@ import { vi } from 'vitest';
 
 vi.mock('../../lib/supabaseClient', () => ({
   supabase: { from: vi.fn() },
-  useSupabaseWithClerk: () => supabase
+  useSupabase: () => supabase
 }));
 
 const user = { id: 'advisor1' };

--- a/src/hooks/useSupabase.js
+++ b/src/hooks/useSupabase.js
@@ -1,0 +1,1 @@
+export { useSupabase } from '../lib/supabaseClient';

--- a/src/hooks/useSupabaseClientWithClerk.js
+++ b/src/hooks/useSupabaseClientWithClerk.js
@@ -1,1 +1,2 @@
-export { useSupabaseWithClerk as default } from '../lib/supabaseClient';
+// Temporary shim to maintain backwards compatibility
+export { useSupabase as default } from '../lib/supabaseClient';

--- a/src/lib/supabaseClient.js
+++ b/src/lib/supabaseClient.js
@@ -9,7 +9,7 @@ const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY;
 // Create a single Supabase client instance
 let supabaseInstance = null;
 
-export function useSupabaseWithClerk() {
+export function useSupabase() {
   const { getToken, isLoaded } = useAuth();
   const [supabaseClient, setSupabaseClient] = useState(null);
 

--- a/src/pages/ClientPortal.jsx
+++ b/src/pages/ClientPortal.jsx
@@ -10,14 +10,14 @@ import ClientForm from '../components/forms/ClientForm';
 import ProposalPDF from '../components/proposals/ProposalPDF';
 import LoadingSpinner from '../components/ui/LoadingSpinner';
 import SafeIcon from '../common/SafeIcon';
-import { useSupabaseWithClerk } from '../lib/supabaseClient';
+import { useSupabase } from '../lib/supabaseClient';
 import * as FiIcons from 'react-icons/fi';
 
 const { FiUser, FiEdit, FiBarChart2, FiActivity, FiFileText, FiMail, FiPhone, FiMapPin, FiCalendar, FiUsers, FiBriefcase, FiShield, FiStar, FiBuilding, FiDollarSign, FiTrendingUp, FiSettings } = FiIcons;
 
 const ClientPortal = () => {
   const { user } = useAuth();
-  const supabase = useSupabaseWithClerk();
+  const supabase = useSupabase();
   const { clients, proposals, users, updateClient } = useData();
   const { analysis, loadAnalysis, loading: analysisLoading } = useFinancialAnalysis();
   

--- a/src/pages/FinancialAnalysis.jsx
+++ b/src/pages/FinancialAnalysis.jsx
@@ -14,7 +14,7 @@ import FinancialPlanningSection from '../components/financial/FinancialPlanningS
 import FinancialGoalsSection from '../components/financial/FinancialGoalsSection';
 import LoadingSpinner from '../components/ui/LoadingSpinner';
 import SafeIcon from '../common/SafeIcon';
-import { useSupabaseWithClerk } from '../lib/supabaseClient';
+import { useSupabase } from '../lib/supabaseClient';
 import logDev from '../utils/logDev';
 import * as FiIcons from 'react-icons/fi';
 
@@ -24,7 +24,7 @@ const FinancialAnalysis = () => {
   const { clientId } = useParams(); // Optional - if accessed from client details
   const navigate = useNavigate();
   const { user } = useAuth();
-  const supabase = useSupabaseWithClerk();
+  const supabase = useSupabase();
   const { clients } = useData();
   const { analysis, loadAnalysis, saveAnalysis, setAnalysis, loading } = useFinancialAnalysis();
   const [activeTab, setActiveTab] = useState('cashflow');

--- a/src/pages/ProjectionsSettings.jsx
+++ b/src/pages/ProjectionsSettings.jsx
@@ -9,14 +9,14 @@ import CarriersManager from '../components/admin/CarriersManager';
 import LoadingSpinner from '../components/ui/LoadingSpinner';
 import SafeIcon from '../common/SafeIcon';
 import * as FiIcons from 'react-icons/fi';
-import { useSupabaseWithClerk } from '../lib/supabaseClient';
+import { useSupabase } from '../lib/supabaseClient';
 import logDev from '../utils/logDev';
 
 const { FiSettings, FiShield, FiAlertTriangle } = FiIcons;
 
 const ProjectionsSettings = () => {
   const { user } = useAuth();
-  const supabase = useSupabaseWithClerk();
+  const supabase = useSupabase();
   logDev('ProjectionsSettings user role:', user?.role);
   const navigate = useNavigate();
   const [activeTab, setActiveTab] = useState('strategies');

--- a/src/pages/ProposalManagement.jsx
+++ b/src/pages/ProposalManagement.jsx
@@ -14,7 +14,7 @@ import ProductConfiguration from '../components/proposals/ProductConfiguration';
 import ProposalPDF from '../components/proposals/ProposalPDF';
 import SafeIcon from '../common/SafeIcon';
 import * as FiIcons from 'react-icons/fi';
-import { useSupabaseWithClerk } from '../lib/supabaseClient';
+import { useSupabase } from '../lib/supabaseClient';
 
 const { FiPlus, FiSearch, FiEdit, FiTrash2, FiEye, FiSend, FiCalendar, FiUser, FiDownload, FiPrinter } = FiIcons;
 
@@ -144,7 +144,7 @@ const DEFAULT_CARRIERS = [
 
 const ProposalManagement = () => {
   const { user } = useAuth();
-  const supabase = useSupabaseWithClerk();
+  const supabase = useSupabase();
   const { proposals, clients, users, addProposal, updateProposal, deleteProposal } = useData();
   const [isAddModalOpen, setIsAddModalOpen] = useState(false);
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);


### PR DESCRIPTION
## Summary
- add `useSupabase` hook and migrate all components
- update contexts and pages to use Supabase user ids
- shim old `useSupabaseClientWithClerk` for compatibility
- adjust tests for new hook

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68806c659ae08333b5ce845409e77a8c