### PR TITLE
Fix CRM notes column name

### DIFF
--- a/supabase/migrations/001_initial.sql
+++ b/supabase/migrations/001_initial.sql
@@ -96,7 +96,7 @@ CREATE TABLE public.crm_client_notes_pf (
   id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
   client_id uuid REFERENCES public.clients_pf(id) ON DELETE CASCADE,
   advisor_id uuid REFERENCES public.users_pf(id) ON DELETE CASCADE,
-  content text NOT NULL,
+  note text NOT NULL,
   created_at timestamptz NOT NULL DEFAULT now(),
   updated_at timestamptz
 );


### PR DESCRIPTION
## Summary
- rename `content` column to `note` in the initial migration

## Testing
- `npx vitest run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688158e1d94c8333af1b7957222b6cf0