### PR TITLE
Fix insert data to omit UUID primary keys

### DIFF
--- a/src/contexts/DataContext.jsx
+++ b/src/contexts/DataContext.jsx
@@ -127,6 +127,7 @@ export const DataProvider = ({ children }) => {
       // Strip any CRM related fields before inserting. CRM records are managed
       // separately via the CrmContext.
       const {
+        id, // exclude primary key when inserting
         crm_status,
         crm_notes,
         crm_tasks,
@@ -215,9 +216,11 @@ export const DataProvider = ({ children }) => {
     }
 
     try {
+      const { id, ...cleanUserData } = userData;
+
       const { data, error } = await supabase
         .from('users_pf')
-        .insert({ ...userData, advisor_id: user.supabaseId })
+        .insert({ ...cleanUserData, advisor_id: user.supabaseId })
         .select();
       if (error) throw error;
 
@@ -278,9 +281,11 @@ export const DataProvider = ({ children }) => {
     }
 
     try {
+      const { id, ...cleanProposal } = proposal;
+
       const { data, error } = await supabase
         .from('projections_pf')
-        .insert({ ...proposal, advisor_id: user.supabaseId })
+        .insert({ ...cleanProposal, advisor_id: user.supabaseId })
         .select();
       if (error) throw error;
 


### PR DESCRIPTION
## Summary
- strip `id` fields from client, user, and proposal inserts
- allow DB to auto generate UUID primary keys

## Testing
- `npm install` *(to install dependencies)*
- `npx vitest run` *(fails: no test files found / interactive errors)*

------
https://chatgpt.com/codex/tasks/task_e_688176b7ede883338a87c5e1c1fca571