### PR TITLE
Fix duplicate Supabase clients

### DIFF
--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -1,10 +1,5 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
-import { createClient } from '@supabase/supabase-js';
-
-const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL;
-const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY;
-
-const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+import { supabase } from '../lib/supabaseClient';
 
 const AuthContext = createContext();
 


### PR DESCRIPTION
## Summary
- use the singleton Supabase client inside `AuthContext`
- keep unit tests passing

## Testing
- `npm test`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6882a200083c83338649842006b685f5