### PR TITLE
Update role logic to use advisor

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -86,7 +86,7 @@ function App() {
               <Route
                 path="/crm"
                 element={
-                  <PrivateRoute allowedRoles={['admin', 'manager', 'financial_professional']}>
+                  <PrivateRoute allowedRoles={['admin', 'manager', 'advisor']}>
                     <CRMDashboard />
                   </PrivateRoute>
                 }
@@ -94,7 +94,7 @@ function App() {
               <Route
                 path="/clients/:clientId/crm"
                 element={
-                  <PrivateRoute allowedRoles={['admin', 'manager', 'financial_professional']}>
+                  <PrivateRoute allowedRoles={['admin', 'manager', 'advisor']}>
                     <ClientCRM />
                   </PrivateRoute>
                 }
@@ -102,7 +102,7 @@ function App() {
               <Route
                 path="/clients"
                 element={
-                  <PrivateRoute allowedRoles={['admin', 'manager', 'financial_professional']}>
+                  <PrivateRoute allowedRoles={['admin', 'manager', 'advisor']}>
                     <ClientManagement />
                   </PrivateRoute>
                 }
@@ -110,7 +110,7 @@ function App() {
               <Route
                 path="/clients/:clientId"
                 element={
-                  <PrivateRoute allowedRoles={['admin', 'manager', 'financial_professional']}>
+                  <PrivateRoute allowedRoles={['admin', 'manager', 'advisor']}>
                     <ClientDetails />
                   </PrivateRoute>
                 }
@@ -118,7 +118,7 @@ function App() {
               <Route
                 path="/financial-analysis"
                 element={
-                  <PrivateRoute allowedRoles={['admin', 'manager', 'financial_professional']}>
+                  <PrivateRoute allowedRoles={['admin', 'manager', 'advisor']}>
                     <FinancialAnalysis />
                   </PrivateRoute>
                 }
@@ -126,7 +126,7 @@ function App() {
               <Route
                 path="/financial-analysis/:clientId"
                 element={
-                  <PrivateRoute allowedRoles={['admin', 'manager', 'financial_professional']}>
+                  <PrivateRoute allowedRoles={['admin', 'manager', 'advisor']}>
                     <FinancialAnalysis />
                   </PrivateRoute>
                 }
@@ -135,7 +135,7 @@ function App() {
               <Route
                 path="/proposals"
                 element={
-                  <PrivateRoute allowedRoles={['admin', 'manager', 'financial_professional']}>
+                  <PrivateRoute allowedRoles={['admin', 'manager', 'advisor']}>
                     <ProposalManagement />
                   </PrivateRoute>
                 }

--- a/src/components/auth/UserRoleManager.jsx
+++ b/src/components/auth/UserRoleManager.jsx
@@ -18,7 +18,7 @@ const TEAM_IDS = [
 const ROLES = [
   { id: 'admin', name: 'Administrator', icon: FiShield },
   { id: 'manager', name: 'Manager', icon: FiUsers },
-  { id: 'financial_professional', name: 'Financial Professional', icon: FiBriefcase },
+  { id: 'advisor', name: 'Advisor', icon: FiBriefcase },
   { id: 'client', name: 'Client', icon: FiUser }
 ];
 
@@ -198,7 +198,7 @@ const UserRoleManager = ({ userId }) => {
           </select>
         </div>
         
-        {(formData.role === 'manager' || formData.role === 'financial_professional') && (
+        {(formData.role === 'manager' || formData.role === 'advisor') && (
           <div>
             <label htmlFor="teamId" className="block text-sm font-medium text-gray-700 mb-2">
               Team

--- a/src/config/routes.jsx
+++ b/src/config/routes.jsx
@@ -18,7 +18,7 @@ import ProjectionsSettings from '../pages/ProjectionsSettings';
 export const ROLES = {
   ADMIN: 'admin',
   MANAGER: 'manager',
-  FINANCIAL_PROFESSIONAL: 'financial_professional',
+  ADVISOR: 'advisor',
   CLIENT: 'client'
 };
 
@@ -38,13 +38,13 @@ export const routes = [
     path: '/crm',
     element: <CRMDashboard />,
     requireAuth: true,
-    allowedRoles: [ROLES.ADMIN, ROLES.MANAGER, ROLES.FINANCIAL_PROFESSIONAL]
+    allowedRoles: [ROLES.ADMIN, ROLES.MANAGER, ROLES.ADVISOR]
   },
   {
     path: '/clients/:clientId/crm',
     element: <ClientCRM />,
     requireAuth: true,
-    allowedRoles: [ROLES.ADMIN, ROLES.MANAGER, ROLES.FINANCIAL_PROFESSIONAL]
+    allowedRoles: [ROLES.ADMIN, ROLES.MANAGER, ROLES.ADVISOR]
   },
   {
     path: '/client-portal',
@@ -62,25 +62,25 @@ export const routes = [
     path: '/clients',
     element: <ClientManagement />,
     requireAuth: true,
-    allowedRoles: [ROLES.ADMIN, ROLES.MANAGER, ROLES.FINANCIAL_PROFESSIONAL]
+    allowedRoles: [ROLES.ADMIN, ROLES.MANAGER, ROLES.ADVISOR]
   },
   {
     path: '/clients/:clientId',
     element: <ClientDetails />,
     requireAuth: true,
-    allowedRoles: [ROLES.ADMIN, ROLES.MANAGER, ROLES.FINANCIAL_PROFESSIONAL]
+    allowedRoles: [ROLES.ADMIN, ROLES.MANAGER, ROLES.ADVISOR]
   },
   {
     path: '/financial-analysis',
     element: <FinancialAnalysis />,
     requireAuth: true,
-    allowedRoles: [ROLES.ADMIN, ROLES.MANAGER, ROLES.FINANCIAL_PROFESSIONAL]
+    allowedRoles: [ROLES.ADMIN, ROLES.MANAGER, ROLES.ADVISOR]
   },
   {
     path: '/financial-analysis/:clientId',
     element: <FinancialAnalysis />,
     requireAuth: true,
-    allowedRoles: [ROLES.ADMIN, ROLES.MANAGER, ROLES.FINANCIAL_PROFESSIONAL]
+    allowedRoles: [ROLES.ADMIN, ROLES.MANAGER, ROLES.ADVISOR]
   },
   {
     path: '/clients/:clientId/report',
@@ -91,7 +91,7 @@ export const routes = [
     path: '/proposals',
     element: <ProposalManagement />,
     requireAuth: true,
-    allowedRoles: [ROLES.ADMIN, ROLES.MANAGER, ROLES.FINANCIAL_PROFESSIONAL]
+    allowedRoles: [ROLES.ADMIN, ROLES.MANAGER, ROLES.ADVISOR]
   },
   {
     path: '/users',

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -220,7 +220,7 @@ export const AuthProvider = ({ children }) => {
 
   const isAdmin = user?.role === 'admin';
   const isManager = user?.role === 'manager';
-  const isFinancialProfessional = user?.role === 'financial_professional';
+  const isAdvisor = user?.role === 'advisor';
   const isClient = user?.role === 'client';
 
   const hasRole = (role) => user?.role === role;
@@ -237,7 +237,7 @@ export const AuthProvider = ({ children }) => {
     updateProfile,
     isAdmin,
     isManager,
-    isFinancialProfessional,
+    isAdvisor,
     isClient,
     hasRole,
     hasAnyRole,

--- a/src/pages/CRMDashboard.jsx
+++ b/src/pages/CRMDashboard.jsx
@@ -30,7 +30,7 @@ const CRMDashboard = () => {
     let clientList = clients;
 
     // Filter by role
-    if (user?.role === 'financial_professional') {
+    if (user?.role === 'advisor') {
       clientList = clients.filter(client => client.advisorId === user.id);
     }
 

--- a/src/pages/ClientManagement.jsx
+++ b/src/pages/ClientManagement.jsx
@@ -35,7 +35,7 @@ const ClientManagement = () => {
                            client.email.toLowerCase().includes(searchTerm.toLowerCase());
 
       // Filter by role
-      if (user?.role === 'financial_professional') {
+      if (user?.role === 'advisor') {
         if (!matchesSearch || client.advisorId !== user.id) {
           return false;
         }

--- a/src/pages/FinancialAnalysis.jsx
+++ b/src/pages/FinancialAnalysis.jsx
@@ -39,7 +39,7 @@ const FinancialAnalysis = () => {
 
   // Filter clients based on user role
   const availableClients = clients.filter(client => {
-    if (user?.role === 'financial_professional') {
+    if (user?.role === 'advisor') {
       return client.advisorId === user.id;
     }
     return true;

--- a/src/pages/ProposalManagement.jsx
+++ b/src/pages/ProposalManagement.jsx
@@ -183,7 +183,7 @@ const ProposalManagement = () => {
   const filteredProposals = proposals.filter(proposal => {
     const matchesSearch = proposal.title.toLowerCase().includes(searchTerm.toLowerCase()) || 
                           proposal.description.toLowerCase().includes(searchTerm.toLowerCase());
-    if (user?.role === 'financial_professional') {
+    if (user?.role === 'advisor') {
       return matchesSearch && proposal.advisorId === user.id;
     }
     return matchesSearch;
@@ -195,7 +195,7 @@ const ProposalManagement = () => {
   };
 
   const availableClients = clients.filter(client => {
-    if (user?.role === 'financial_professional') {
+    if (user?.role === 'advisor') {
       return client.advisorId === user.id;
     }
     return true;

--- a/src/pages/Signup.jsx
+++ b/src/pages/Signup.jsx
@@ -9,7 +9,7 @@ import * as FiIcons from 'react-icons/fi';
 
 const { FiMail, FiLock, FiEye, FiEyeOff, FiUser, FiPhone, FiArrowLeft, FiUserPlus, FiBriefcase } = FiIcons;
 
-// Team ID options for financial professionals
+// Team ID options for advisors
 const TEAM_IDS = [
   { id: 'emd_rodriguez', name: 'EMD Rodriguez' },
   { id: 'md_garcia', name: 'MD Garcia' },
@@ -66,7 +66,7 @@ const Signup = () => {
       setError('Passwords do not match');
       return false;
     }
-    if (formData.role === 'financial_professional' && !formData.teamId) {
+    if (formData.role === 'advisor' && !formData.teamId) {
       setError('Please select a team');
       return false;
     }
@@ -88,9 +88,9 @@ const Signup = () => {
     setError('');
 
     try {
-      // Generate agent code automatically for financial professionals
+      // Generate agent code automatically for advisors
       let agentCode = '';
-      if (formData.role === 'financial_professional') {
+      if (formData.role === 'advisor') {
         agentCode = `FP${Math.floor(Math.random() * 10000).toString().padStart(4, '0')}`;
       }
 
@@ -118,7 +118,7 @@ const Signup = () => {
         setSuccess(true);
 
         setTimeout(() => {
-          if (formData.role === 'financial_professional') {
+          if (formData.role === 'advisor') {
             navigate('/advisor/dashboard');
           } else {
             navigate('/client/dashboard');
@@ -137,7 +137,7 @@ const Signup = () => {
 
 
 
-  const isFinancialProfessional = formData.role === 'financial_professional';
+  const isAdvisor = formData.role === 'advisor';
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-primary-50 to-secondary-50 flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
@@ -215,7 +215,7 @@ const Signup = () => {
                   required
                 >
                   <option value="client">Client</option>
-                  <option value="financial_professional">Financial Professional</option>
+                  <option value="advisor">Advisor</option>
                 </select>
               </div>
 
@@ -334,8 +334,8 @@ const Signup = () => {
                 </div>
               </div>
 
-              {/* Team selection only for financial professionals */}
-              {isFinancialProfessional && (
+              {/* Team selection only for advisors */}
+              {isAdvisor && (
                 <div>
                   <label htmlFor="teamId" className="block text-sm font-medium text-gray-700 mb-2">
                     Team *

--- a/src/pages/UserManagement.jsx
+++ b/src/pages/UserManagement.jsx
@@ -112,7 +112,7 @@ const UserManagement = () => {
     switch (role) {
       case 'admin': return 'Administrator';
       case 'manager': return 'Manager';
-      case 'financial_professional': return 'Financial Professional';
+      case 'advisor': return 'Advisor';
       case 'client': return 'Client';
       default: return role;
     }
@@ -348,7 +348,7 @@ const UserManagement = () => {
                     <option value="manager">Manager</option>
                   </>
                 )}
-                <option value="financial_professional">Financial Professional</option>
+                <option value="advisor">Advisor</option>
                 <option value="client">Client</option>
               </select>
             </div>

--- a/src/utils/menuByRole.js
+++ b/src/utils/menuByRole.js
@@ -3,7 +3,7 @@
 // Expected role values:
 // - 'admin'
 // - 'manager'
-// - 'financial_professional'
+// - 'advisor'
 // - 'client'
 // Any other value will be treated as a basic user.
 


### PR DESCRIPTION
## Summary
- rename `financial_professional` role to `advisor`
- update signup flow to handle advisor role
- adjust role-based routing and checks
- revise role labels and constants

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882df8f022083338db8608ad93db44e