### PR TITLE
Handle empty numeric fields in proposal save

### DIFF
--- a/src/pages/ProposalManagement.jsx
+++ b/src/pages/ProposalManagement.jsx
@@ -202,16 +202,43 @@ const ProposalManagement = () => {
     return true;
   });
 
+  const numericFields = [
+    'initialLumpSum',
+    'monthlyContribution',
+    'annualCOI',
+    'firstYearBonus',
+    'yearsToPay',
+    'averageReturnPercentage',
+    'deathBenefitAmount',
+    'livingBenefits',
+    'terminalIllnessBenefit',
+    'chronicIllnessBenefit',
+    'criticalIllnessBenefit',
+    'averageMonthlyCost',
+    'tenYearIncome',
+    'lifetimeIncome'
+  ];
+
+  const cleanNumericFields = (data) => {
+    const cleaned = { ...data };
+    numericFields.forEach((field) => {
+      if (cleaned[field] === '') {
+        cleaned[field] = null;
+      }
+    });
+    return cleaned;
+  };
+
   const handleSubmit = async (e) => {
     e.preventDefault();
     setIsSubmitting(true);
 
     try {
-      const proposalData = {
+      const proposalData = cleanNumericFields({
         ...formData,
         createdBy: user.id,
         status: selectedProposal ? selectedProposal.status : 'draft'
-      };
+      });
 
       const snakeCaseData = decamelizeKeys(proposalData);
       logDev('Saving proposal (snake_case):', snakeCaseData);


### PR DESCRIPTION
## Summary
- sanitize numeric fields before saving proposals to DB

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6884234b70008333b0983eaa96155bf0