### PR TITLE
Add Publitio upload helpers and components

### DIFF
--- a/src/components/uploads/DocumentManager.jsx
+++ b/src/components/uploads/DocumentManager.jsx
@@ -1,0 +1,56 @@
+import React, { useState } from 'react';
+import * as FiIcons from 'react-icons/fi';
+import SafeIcon from '../../common/SafeIcon';
+import FileUpload from './FileUpload';
+import { deleteFile } from '../../services/publitio';
+
+const { FiTrash2, FiFileText } = FiIcons;
+
+const DocumentManager = ({ initialFiles = [], folder = 'documents', onChange }) => {
+  const [files, setFiles] = useState(initialFiles);
+  const [error, setError] = useState('');
+
+  const handleUpload = (file) => {
+    const updated = [...files, file];
+    setFiles(updated);
+    onChange && onChange(updated);
+  };
+
+  const handleDelete = async (file) => {
+    if (!window.confirm('Delete this file?')) return;
+    try {
+      await deleteFile(file.public_id);
+      const updated = files.filter(f => f.public_id !== file.public_id);
+      setFiles(updated);
+      onChange && onChange(updated);
+    } catch (err) {
+      setError(err.message || 'Delete failed');
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <FileUpload folder={folder} onComplete={handleUpload} />
+      {error && <p className="text-sm text-danger-600">{error}</p>}
+      <ul className="space-y-2">
+        {files.map(file => (
+          <li key={file.public_id} className="flex items-center justify-between">
+            <a href={file.url} target="_blank" rel="noopener" className="flex items-center space-x-2 text-primary-600 hover:underline">
+              <SafeIcon icon={FiFileText} className="w-4 h-4" />
+              <span>{file.url.split('/').pop()}</span>
+            </a>
+            <button
+              type="button"
+              onClick={() => handleDelete(file)}
+              className="p-1 rounded hover:bg-gray-100 text-danger-600"
+            >
+              <SafeIcon icon={FiTrash2} className="w-4 h-4" />
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default DocumentManager;

--- a/src/components/uploads/FileUpload.jsx
+++ b/src/components/uploads/FileUpload.jsx
@@ -1,0 +1,76 @@
+import React, { useRef, useState } from 'react';
+import * as FiIcons from 'react-icons/fi';
+import SafeIcon from '../../common/SafeIcon';
+import { uploadFile } from '../../services/publitio';
+import LoadingSpinner from '../ui/LoadingSpinner';
+
+const { FiUpload } = FiIcons;
+
+const MAX_SIZE = 10 * 1024 * 1024; // 10MB
+
+const FileUpload = ({ accept = '*/*', folder = '', onComplete }) => {
+  const inputRef = useRef();
+  const [progress, setProgress] = useState(0);
+  const [error, setError] = useState('');
+  const [uploading, setUploading] = useState(false);
+
+  const handleChange = async (e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+    setError('');
+    setProgress(0);
+
+    if (file.size > MAX_SIZE) {
+      setError('File is too large');
+      return;
+    }
+    if (accept !== '*/*' && !file.type.match(accept.replace('*', '.*'))) {
+      setError('Invalid file type');
+      return;
+    }
+
+    try {
+      setUploading(true);
+      const result = await uploadFile(file, folder);
+      setProgress(100);
+      onComplete && onComplete(result);
+      inputRef.current.value = '';
+    } catch (err) {
+      setError(err.message || 'Upload failed');
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      <label className="btn-secondary inline-flex items-center space-x-2 cursor-pointer">
+        <SafeIcon icon={FiUpload} className="w-4 h-4" />
+        <span>Upload</span>
+        <input
+          ref={inputRef}
+          type="file"
+          accept={accept}
+          onChange={handleChange}
+          className="hidden"
+        />
+      </label>
+      {uploading && (
+        <div className="w-full bg-gray-200 rounded-full h-2">
+          <div
+            className="bg-primary-600 h-2 rounded-full"
+            style={{ width: `${progress}%` }}
+          />
+        </div>
+      )}
+      {uploading && progress < 100 && (
+        <p className="text-xs text-gray-500">Uploading...</p>
+      )}
+      {error && (
+        <p className="text-sm text-danger-600">{error}</p>
+      )}
+    </div>
+  );
+};
+
+export default FileUpload;

--- a/src/components/uploads/ProfileImageUpload.jsx
+++ b/src/components/uploads/ProfileImageUpload.jsx
@@ -1,0 +1,24 @@
+import React, { useState } from 'react';
+import FileUpload from './FileUpload';
+
+const ProfileImageUpload = ({ initialUrl, folder = 'avatars', onChange }) => {
+  const [preview, setPreview] = useState(initialUrl || '');
+
+  const handleComplete = (file) => {
+    setPreview(file.url);
+    onChange && onChange(file);
+  };
+
+  return (
+    <div className="flex flex-col items-center space-y-2">
+      <img
+        src={preview || 'https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?w=100&h=100&fit=crop&crop=face'}
+        alt="Profile"
+        className="w-32 h-32 rounded-full object-cover"
+      />
+      <FileUpload accept="image/*" folder={folder} onComplete={handleComplete} />
+    </div>
+  );
+};
+
+export default ProfileImageUpload;

--- a/src/services/publitio.js
+++ b/src/services/publitio.js
@@ -1,0 +1,46 @@
+import { supabase } from '../lib/supabaseClient';
+
+const baseUrl = import.meta.env.VITE_SUPABASE_URL
+  .replace('.supabase.co', '.functions.supabase.co') + '/publitio-proxy';
+
+export async function uploadFile(file, folder = '') {
+  if (!file) throw new Error('File is required');
+  const { data: { session } } = await supabase.auth.getSession();
+  const token = session?.access_token;
+  if (!token) throw new Error('Not authenticated');
+
+  const formData = new FormData();
+  formData.append('file', file);
+  if (folder) {
+    const ext = file.name.split('.').pop();
+    const name = `${folder}/${Date.now()}_${Math.random().toString(36).slice(2)}.${ext}`;
+    formData.append('public_id', name);
+  }
+
+  const res = await fetch(baseUrl, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}` },
+    body: formData
+  });
+  const data = await res.json();
+  if (!res.ok) {
+    throw new Error(data.error || 'Upload failed');
+  }
+  return data; // { public_id, url }
+}
+
+export async function deleteFile(publicId) {
+  const { data: { session } } = await supabase.auth.getSession();
+  const token = session?.access_token;
+  if (!token) throw new Error('Not authenticated');
+  const url = `${baseUrl}?public_id=${encodeURIComponent(publicId)}`;
+  const res = await fetch(url, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${token}` }
+  });
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({}));
+    throw new Error(data.error || 'Delete failed');
+  }
+  return true;
+}


### PR DESCRIPTION
## Summary
- add publitio service with upload and delete helpers
- create FileUpload component for uploading files with progress and error handling
- create ProfileImageUpload for uploading profile pictures with preview
- create DocumentManager to manage uploaded documents

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68844ac5b1088333aeac784978922c84