### PR TITLE
Add Publitio image transformation helper

### DIFF
--- a/src/components/admin/CarriersManager.jsx
+++ b/src/components/admin/CarriersManager.jsx
@@ -4,6 +4,7 @@ import Modal from '../ui/Modal';
 import LoadingSpinner from '../ui/LoadingSpinner';
 import SafeIcon from '../../common/SafeIcon';
 import * as FiIcons from 'react-icons/fi';
+import { getTransformedImage } from '../../services/publitio';
 import { useSupabaseClient } from '../../lib/supabaseClient';
 import { useAuth } from '../../hooks/useAuth';
 import logDev from '../../utils/logDev';
@@ -406,7 +407,7 @@ const CarriersManager = () => {
                 <div className="flex items-center space-x-3">
                   {carrier.logo_url ? (
                     <img
-                      src={carrier.logo_url}
+                      src={getTransformedImage(carrier.logo_url, { width: 128, height: 128 })}
                       alt={carrier.name}
                       className="w-16 h-16 object-contain rounded-lg bg-gray-50 p-1"
                       onError={(e) => {
@@ -529,7 +530,11 @@ const CarriersManager = () => {
               {logoPreview ? (
                 <div className="relative">
                   <img
-                    src={logoPreview}
+                    src={
+                      logoPreview && logoPreview.startsWith('http')
+                        ? getTransformedImage(logoPreview, { width: 192, height: 192 })
+                        : logoPreview
+                    }
                     alt="Logo Preview"
                     className="w-24 h-24 object-contain rounded-lg bg-gray-50 p-2"
                   />
@@ -698,7 +703,11 @@ const CarriersManager = () => {
               {logoPreview ? (
                 <div className="relative">
                   <img
-                    src={logoPreview}
+                    src={
+                      logoPreview && logoPreview.startsWith('http')
+                        ? getTransformedImage(logoPreview, { width: 192, height: 192 })
+                        : logoPreview
+                    }
                     alt="Logo Preview"
                     className="w-24 h-24 object-contain rounded-lg bg-gray-50 p-2"
                   />

--- a/src/components/auth/UserRoleManager.jsx
+++ b/src/components/auth/UserRoleManager.jsx
@@ -5,6 +5,7 @@ import { motion } from 'framer-motion';
 import LoadingSpinner from '../ui/LoadingSpinner';
 import SafeIcon from '../../common/SafeIcon';
 import * as FiIcons from 'react-icons/fi';
+import { getTransformedImage } from '../../services/publitio';
 
 const { FiUser, FiUsers, FiShield, FiBriefcase, FiSave, FiAlertTriangle } = FiIcons;
 
@@ -166,8 +167,14 @@ const UserRoleManager = ({ userId }) => {
       )}
       
       <div className="flex items-center space-x-4 mb-6">
-        <img 
-          src={user.imageUrl || `https://ui-avatars.com/api/?name=${encodeURIComponent(user.firstName + ' ' + user.lastName)}&background=random`} 
+        <img
+          src={
+            user.imageUrl
+              ? getTransformedImage(user.imageUrl, { width: 96, height: 96 })
+              : `https://ui-avatars.com/api/?name=${encodeURIComponent(
+                  user.firstName + ' ' + user.lastName
+                )}&background=random`
+          }
           alt={user.firstName}
           className="w-12 h-12 rounded-full object-cover"
         />

--- a/src/components/layout/Navbar.jsx
+++ b/src/components/layout/Navbar.jsx
@@ -6,6 +6,7 @@ import menuByRole from '../../utils/menuByRole';
 import { motion, AnimatePresence } from 'framer-motion';
 import SafeIcon from '../../common/SafeIcon';
 import * as FiIcons from 'react-icons/fi';
+import { getTransformedImage } from '../../services/publitio';
 
 const { FiLogOut, FiChevronDown, FiUser, FiSettings } = FiIcons;
 
@@ -73,7 +74,13 @@ const Navbar = () => {
               className="flex items-center space-x-3 p-2 rounded-lg hover:bg-gray-50 transition-colors"
             >
               <img
-                src={user?.imageUrl || `https://ui-avatars.com/api/?name=${encodeURIComponent(user?.fullName || 'User')}&background=random`}
+                src={
+                  user?.imageUrl
+                    ? getTransformedImage(user.imageUrl, { width: 64, height: 64 })
+                    : `https://ui-avatars.com/api/?name=${encodeURIComponent(
+                        user?.fullName || 'User'
+                      )}&background=random`
+                }
                 alt={user?.fullName || 'User'}
                 className="w-8 h-8 rounded-full object-cover"
               />

--- a/src/components/proposals/CarrierSelector.jsx
+++ b/src/components/proposals/CarrierSelector.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import SafeIcon from '../../common/SafeIcon';
 import * as FiIcons from 'react-icons/fi';
+import { getTransformedImage } from '../../services/publitio';
 import { useSupabaseClient } from '../../lib/supabaseClient';
 import LoadingSpinner from '../ui/LoadingSpinner';
 
@@ -129,7 +130,7 @@ const CarrierSelector = ({ selectedCarrier, onCarrierChange, selectedProduct }) 
             <div className="flex items-start space-x-3">
               {carrier.logo_url ? (
                 <img
-                  src={carrier.logo_url}
+                  src={getTransformedImage(carrier.logo_url, { width: 96, height: 96 })}
                   alt={carrier.name}
                   className="w-12 h-12 rounded-lg object-contain bg-white p-1"
                   onError={(e) => {

--- a/src/pages/ProposalManagement.jsx
+++ b/src/pages/ProposalManagement.jsx
@@ -12,6 +12,7 @@ import StrategySelector from '../components/proposals/StrategySelector';
 import CarrierSelector from '../components/proposals/CarrierSelector';
 import ProductConfiguration from '../components/proposals/ProductConfiguration';
 import ProposalPDF from '../components/proposals/ProposalPDF';
+import { getTransformedImage } from '../services/publitio';
 import SafeIcon from '../common/SafeIcon';
 import * as FiIcons from 'react-icons/fi';
 import { useSupabaseClient } from '../lib/supabaseClient';
@@ -516,7 +517,11 @@ const ProposalManagement = () => {
                   )}
                   {carrier && (
                     <div className="flex items-center space-x-2 text-sm text-gray-600">
-                      <img src={carrier.logo} alt={carrier.name} className="w-4 h-4 rounded" />
+                      <img
+                        src={getTransformedImage(carrier.logo, { width: 32, height: 32 })}
+                        alt={carrier.name}
+                        className="w-4 h-4 rounded"
+                      />
                       <span>{carrier.name}</span>
                     </div>
                   )}

--- a/src/services/publitio.js
+++ b/src/services/publitio.js
@@ -44,3 +44,25 @@ export async function deleteFile(publicId) {
   }
   return true;
 }
+
+export function getTransformedImage(url, options = {}) {
+  if (!url) return '';
+  try {
+    const { width, height, format = 'webp', quality } = options;
+    const u = new URL(url);
+    const parts = u.pathname.split('/');
+    const idx = parts.indexOf('file');
+    if (idx === -1) return url;
+    const transforms = [];
+    if (width) transforms.push(`w_${width}`);
+    if (height) transforms.push(`h_${height}`);
+    if (quality) transforms.push(`q_${quality}`);
+    if (format) transforms.push(`f_${format}`);
+    if (transforms.length === 0) return url;
+    parts.splice(idx + 1, 0, transforms.join(','));
+    u.pathname = parts.join('/');
+    return u.toString();
+  } catch (_) {
+    return url;
+  }
+}


### PR DESCRIPTION
## Summary
- extend Publitio service with `getTransformedImage` helper
- show optimized Publitio images in navbar avatars
- transform user avatars in role manager
- transform carrier logos in selector and management screens
- use helper for carrier logos in Proposal Management

## Testing
- `npm run lint`
- `npm test -- -t Crm`

------
https://chatgpt.com/codex/tasks/task_e_68845958d010833396b8a4f460e7b672