### PR TITLE
Add Publitio service and upload component tests

### DIFF
--- a/src/components/uploads/__tests__/FileUpload.test.jsx
+++ b/src/components/uploads/__tests__/FileUpload.test.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { render, fireEvent, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+
+vi.mock('../../../services/publitio', () => ({
+  uploadFile: vi.fn()
+}));
+
+import { uploadFile } from '../../../services/publitio';
+import FileUpload from '../FileUpload';
+
+function createFile(name = 'test.txt', size = 100, type = 'text/plain') {
+  const file = new File(['a'.repeat(size)], name, { type });
+  return file;
+}
+
+describe('FileUpload', () => {
+  beforeEach(() => {
+    uploadFile.mockReset();
+  });
+
+  it('shows progress while uploading and calls onComplete', async () => {
+    let resolve;
+    uploadFile.mockReturnValue(new Promise(r => { resolve = r; }));
+    const handleComplete = vi.fn();
+    render(<FileUpload onComplete={handleComplete} />);
+
+    const input = screen.getByText('Upload').parentElement.querySelector('input');
+    fireEvent.change(input, { target: { files: [createFile()] } });
+
+    expect(screen.getByText('Uploading...')).toBeInTheDocument();
+    resolve({ public_id: 'id1', url: 'url' });
+
+    await waitFor(() => expect(handleComplete).toHaveBeenCalled());
+    expect(screen.queryByText('Uploading...')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/uploads/__tests__/ProfileImageUpload.test.jsx
+++ b/src/components/uploads/__tests__/ProfileImageUpload.test.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { render, fireEvent, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+
+vi.mock('../FileUpload', () => ({
+  default: ({ onComplete }) => (
+    <button onClick={() => onComplete({ url: 'new.jpg', public_id: 'id1' })}>Upload</button>
+  )
+}));
+
+import ProfileImageUpload from '../ProfileImageUpload';
+
+describe('ProfileImageUpload', () => {
+  it('updates preview after upload', () => {
+    render(<ProfileImageUpload initialUrl="start.jpg" />);
+    const img = screen.getByAltText('Profile');
+    expect(img.src).toContain('start.jpg');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Upload' }));
+    expect(img.src).toContain('new.jpg');
+  });
+});

--- a/src/services/__tests__/publitio.test.js
+++ b/src/services/__tests__/publitio.test.js
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock supabase client
+vi.mock('../../lib/supabaseClient', () => {
+  return {
+    supabase: {
+      auth: {
+        getSession: vi.fn()
+      }
+    }
+  };
+});
+
+let uploadFile;
+let deleteFile;
+let supabase;
+
+beforeEach(async () => {
+  process.env.VITE_SUPABASE_URL = 'https://test.supabase.co';
+  // re-import module to use fresh env
+  vi.resetModules();
+  const mod = await import('../publitio');
+  uploadFile = mod.uploadFile;
+  deleteFile = mod.deleteFile;
+  supabase = (await import('../../lib/supabaseClient')).supabase;
+  global.fetch = vi.fn();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('uploadFile', () => {
+  it('uploads successfully', async () => {
+    const file = new File(['data'], 'test.txt', { type: 'text/plain' });
+    supabase.auth.getSession.mockResolvedValue({ data: { session: { access_token: 'tok' } } });
+    fetch.mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ public_id: 'id1', url: 'url' })
+    });
+
+    const data = await uploadFile(file, 'docs');
+
+    expect(fetch).toHaveBeenCalled();
+    expect(data).toEqual({ public_id: 'id1', url: 'url' });
+  });
+
+  it('throws on failure', async () => {
+    const file = new File(['data'], 'test.txt', { type: 'text/plain' });
+    supabase.auth.getSession.mockResolvedValue({ data: { session: { access_token: 'tok' } } });
+    fetch.mockResolvedValue({
+      ok: false,
+      json: vi.fn().mockResolvedValue({ error: 'fail' })
+    });
+
+    await expect(uploadFile(file)).rejects.toThrow('fail');
+  });
+});
+
+describe('deleteFile', () => {
+  it('deletes successfully', async () => {
+    supabase.auth.getSession.mockResolvedValue({ data: { session: { access_token: 'tok' } } });
+    fetch.mockResolvedValue({ ok: true, json: vi.fn() });
+
+    const result = await deleteFile('id1');
+
+    expect(fetch).toHaveBeenCalled();
+    expect(result).toBe(true);
+  });
+
+  it('throws on failure', async () => {
+    supabase.auth.getSession.mockResolvedValue({ data: { session: { access_token: 'tok' } } });
+    fetch.mockResolvedValue({ ok: false, json: vi.fn().mockResolvedValue({ error: 'bad' }) });
+
+    await expect(deleteFile('id1')).rejects.toThrow('bad');
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for Publitio upload and delete helpers
- add component tests for FileUpload progress and ProfileImageUpload preview

## Testing
- `npx vitest run --no-watch`

------
https://chatgpt.com/codex/tasks/task_e_688469ada3408333b01592ea2dcb6b02