### PR TITLE
Fix default avatar constant

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,14 @@ Each financial analysis receives a unique **FNA code**. This code is automatical
 
 * The application generates the FNA code automatically when a new analysis is saved.
 * The code is shown on the Financial Analysis page right beside the save confirmation.
+
 * Clients can enter this code in the portal to claim the analysis and link it to their account.
+
+## Default Avatar
+
+All profiles fall back to a Publitio-hosted avatar image when no user photo is available. The URL is exported from `src/utils/constants.js` as `DEFAULT_AVATAR_URL` and used throughout the app.
+
+## Publitio Proxy Function
 
 ## Publitio Proxy Function
 

--- a/src/components/uploads/ProfileImageUpload.jsx
+++ b/src/components/uploads/ProfileImageUpload.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import FileUpload from './FileUpload';
+import { DEFAULT_AVATAR_URL } from '../../utils/constants';
 
 const ProfileImageUpload = ({ initialUrl, folder = 'avatars', onChange }) => {
   const [preview, setPreview] = useState(initialUrl || '');
@@ -12,7 +13,7 @@ const ProfileImageUpload = ({ initialUrl, folder = 'avatars', onChange }) => {
   return (
     <div className="flex flex-col items-center space-y-2">
       <img
-        src={preview || 'https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?w=100&h=100&fit=crop&crop=face'}
+        src={preview || DEFAULT_AVATAR_URL}
         alt="Profile"
         className="w-32 h-32 rounded-full object-cover"
       />

--- a/src/pages/ClientPortal.jsx
+++ b/src/pages/ClientPortal.jsx
@@ -11,6 +11,7 @@ import ProposalPDF from '../components/proposals/ProposalPDF';
 import LoadingSpinner from '../components/ui/LoadingSpinner';
 import SafeIcon from '../common/SafeIcon';
 import { getProfileImageUrl } from '../utils/profileImage';
+import { DEFAULT_AVATAR_URL } from '../utils/constants';
 import { useSupabaseClient } from '../lib/supabaseClient';
 import * as FiIcons from 'react-icons/fi';
 
@@ -626,7 +627,7 @@ const ClientPortal = () => {
               carrier={latestProposal.carrier ? {
                 id: latestProposal.carrier,
                 name: latestProposal.carrier,
-                logo: 'https://images.unsplash.com/photo-1560472354-b33ff0c44a43?w=100&h=100&fit=crop',
+                logo: DEFAULT_AVATAR_URL,
                 rating: 'A+'
               } : null}
               strategy={latestProposal.strategy ? {

--- a/src/pages/ProposalManagement.jsx
+++ b/src/pages/ProposalManagement.jsx
@@ -17,6 +17,7 @@ import SafeIcon from '../common/SafeIcon';
 import * as FiIcons from 'react-icons/fi';
 import { useSupabaseClient } from '../lib/supabaseClient';
 import { decamelizeKeys } from '../utils/decamelize';
+import { DEFAULT_AVATAR_URL } from '../utils/constants';
 
 const { FiPlus, FiSearch, FiEdit, FiTrash2, FiEye, FiSend, FiCalendar, FiUser, FiDownload, FiPrinter } = FiIcons;
 
@@ -97,7 +98,7 @@ const DEFAULT_CARRIERS = [
   {
     id: 'ethos',
     name: 'Ethos',
-    logo: 'https://images.unsplash.com/photo-1560472354-b33ff0c44a43?w=100&h=100&fit=crop',
+    logo: DEFAULT_AVATAR_URL,
     products: ['term_life', 'whole_life', 'universal_life'],
     rating: 'A+',
     established: '2016'
@@ -105,7 +106,7 @@ const DEFAULT_CARRIERS = [
   {
     id: 'fg',
     name: 'F&G (Fidelity & Guaranty)',
-    logo: 'https://images.unsplash.com/photo-1560472354-b33ff0c44a43?w=100&h=100&fit=crop',
+    logo: DEFAULT_AVATAR_URL,
     products: ['fixed_annuity', 'indexed_annuity', 'universal_life'],
     rating: 'A',
     established: '1959'
@@ -113,7 +114,7 @@ const DEFAULT_CARRIERS = [
   {
     id: 'ameritas',
     name: 'Ameritas',
-    logo: 'https://images.unsplash.com/photo-1560472354-b33ff0c44a43?w=100&h=100&fit=crop',
+    logo: DEFAULT_AVATAR_URL,
     products: ['whole_life', 'universal_life', 'variable_universal_life', 'disability_insurance'],
     rating: 'A+',
     established: '1887'
@@ -121,7 +122,7 @@ const DEFAULT_CARRIERS = [
   {
     id: 'mutual_omaha',
     name: 'Mutual of Omaha',
-    logo: 'https://images.unsplash.com/photo-1560472354-b33ff0c44a43?w=100&h=100&fit=crop',
+    logo: DEFAULT_AVATAR_URL,
     products: ['term_life', 'whole_life', 'universal_life', 'disability_insurance'],
     rating: 'A+',
     established: '1909'
@@ -129,7 +130,7 @@ const DEFAULT_CARRIERS = [
   {
     id: 'american_national',
     name: 'American National',
-    logo: 'https://images.unsplash.com/photo-1560472354-b33ff0c44a43?w=100&h=100&fit=crop',
+    logo: DEFAULT_AVATAR_URL,
     products: ['whole_life', 'universal_life', 'variable_universal_life', 'fixed_annuity'],
     rating: 'A',
     established: '1905'
@@ -137,7 +138,7 @@ const DEFAULT_CARRIERS = [
   {
     id: 'american_equity',
     name: 'American Equity',
-    logo: 'https://images.unsplash.com/photo-1560472354-b33ff0c44a43?w=100&h=100&fit=crop',
+    logo: DEFAULT_AVATAR_URL,
     products: ['fixed_annuity', 'indexed_annuity', 'variable_annuity'],
     rating: 'A-',
     established: '1995'

--- a/src/pages/UserManagement.jsx
+++ b/src/pages/UserManagement.jsx
@@ -4,6 +4,7 @@ import { useAuth } from '../hooks/useAuth';
 import { useData } from '../contexts/DataContext';
 import { uploadFile } from '../services/publitio';
 import { getProfileImageUrl } from '../utils/profileImage';
+import { DEFAULT_AVATAR_URL } from '../utils/constants';
 import Navbar from '../components/layout/Navbar';
 import Modal from '../components/ui/Modal';
 import StatusBadge from '../components/ui/StatusBadge';
@@ -75,7 +76,7 @@ const UserManagement = () => {
       userData.profileImageUrl = formData.profileImageUrl;
       userData.avatar = null;
     } else {
-      userData.avatar = formData.avatar || 'https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?w=100&h=100&fit=crop&crop=face';
+      userData.avatar = formData.avatar || DEFAULT_AVATAR_URL;
     }
 
     if (selectedUser) {

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,0 +1,1 @@
+export const DEFAULT_AVATAR_URL = 'https://media.publit.io/file/c_fill,h_200,w_300/pfiw5twH.jpg';

--- a/src/utils/profileImage.js
+++ b/src/utils/profileImage.js
@@ -1,6 +1,5 @@
-export const DEFAULT_AVATAR =
-  'https://media.publit.io/file/c_fill,h_200,w_300/pfiw5twH.jpg';
+import { DEFAULT_AVATAR_URL } from './constants';
 
 export function getProfileImageUrl(user) {
-  return user?.profileImageUrl || user?.avatar || DEFAULT_AVATAR;
+  return user?.profileImageUrl || user?.avatar || DEFAULT_AVATAR_URL;
 }


### PR DESCRIPTION
## Summary
- add `constants.js` for `DEFAULT_AVATAR_URL`
- use the constant when generating profile images
- swap hardcoded Unsplash links for the constant
- document the default avatar URL in README

## Testing
- `npm install`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6886fca4262c83338df133b6438787a5