### PR TITLE
Use profile image helper for all avatars

### DIFF
--- a/src/components/auth/UserRoleManager.jsx
+++ b/src/components/auth/UserRoleManager.jsx
@@ -6,6 +6,7 @@ import LoadingSpinner from '../ui/LoadingSpinner';
 import SafeIcon from '../../common/SafeIcon';
 import * as FiIcons from 'react-icons/fi';
 import { getTransformedImage } from '../../services/publitio';
+import { getProfileImageUrl } from '../../utils/profileImage';
 
 const { FiUser, FiUsers, FiShield, FiBriefcase, FiSave, FiAlertTriangle } = FiIcons;
 
@@ -168,13 +169,10 @@ const UserRoleManager = ({ userId }) => {
       
       <div className="flex items-center space-x-4 mb-6">
         <img
-          src={
-            user.imageUrl
-              ? getTransformedImage(user.imageUrl, { width: 96, height: 96 })
-              : `https://ui-avatars.com/api/?name=${encodeURIComponent(
-                  user.firstName + ' ' + user.lastName
-                )}&background=random`
-          }
+          src={getTransformedImage(
+            getProfileImageUrl(user),
+            { width: 96, height: 96 }
+          )}
           alt={user.firstName}
           className="w-12 h-12 rounded-full object-cover"
         />

--- a/src/components/uploads/ProfileImageUpload.jsx
+++ b/src/components/uploads/ProfileImageUpload.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import FileUpload from './FileUpload';
-import { DEFAULT_AVATAR_URL } from '../../utils/constants';
+import { getProfileImageUrl } from '../../utils/profileImage';
 
 const ProfileImageUpload = ({ initialUrl, folder = 'avatars', onChange }) => {
   const [preview, setPreview] = useState(initialUrl || '');
@@ -13,7 +13,7 @@ const ProfileImageUpload = ({ initialUrl, folder = 'avatars', onChange }) => {
   return (
     <div className="flex flex-col items-center space-y-2">
       <img
-        src={preview || DEFAULT_AVATAR_URL}
+        src={getProfileImageUrl({ profileImageUrl: preview })}
         alt="Profile"
         className="w-32 h-32 rounded-full object-cover"
       />


### PR DESCRIPTION
## Summary
- use `getProfileImageUrl` helper when rendering avatars
- remove ad hoc avatar fallbacks

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68870175759083339c1d78de2fbb87dc