### PR TITLE
Fix scroll wheel changing numbers

### DIFF
--- a/src/components/financial/BalanceSheetSection.jsx
+++ b/src/components/financial/BalanceSheetSection.jsx
@@ -114,6 +114,7 @@ const BalanceSheetSection = ({ assets = [], liabilities = [], onAssetChange, onL
                   type="number"
                   value={getAssetAmount(category.id)}
                   onChange={(e) => handleAssetChange(category.id, e.target.value)}
+                  onWheel={(e) => e.target.blur()}
                   className="form-input w-40"
                   placeholder="Value"
                 />
@@ -160,6 +161,7 @@ const BalanceSheetSection = ({ assets = [], liabilities = [], onAssetChange, onL
                 type="number"
                 value={liability.amount}
                 onChange={(e) => handleUpdateLiability(liability.id, 'amount', e.target.value)}
+                onWheel={(e) => e.target.blur()}
                 className="form-input w-32"
                 placeholder="Amount"
               />
@@ -167,6 +169,7 @@ const BalanceSheetSection = ({ assets = [], liabilities = [], onAssetChange, onL
                 type="number"
                 value={liability.interestRate}
                 onChange={(e) => handleUpdateLiability(liability.id, 'interestRate', e.target.value)}
+                onWheel={(e) => e.target.blur()}
                 className="form-input w-32"
                 placeholder="Interest Rate %"
               />
@@ -205,6 +208,7 @@ const BalanceSheetSection = ({ assets = [], liabilities = [], onAssetChange, onL
               type="number"
               value={newLiability.amount}
               onChange={(e) => setNewLiability({...newLiability, amount: e.target.value})}
+              onWheel={(e) => e.target.blur()}
               className="form-input w-32"
               placeholder="Amount"
             />
@@ -212,6 +216,7 @@ const BalanceSheetSection = ({ assets = [], liabilities = [], onAssetChange, onL
               type="number"
               value={newLiability.interestRate}
               onChange={(e) => setNewLiability({...newLiability, interestRate: e.target.value})}
+              onWheel={(e) => e.target.blur()}
               className="form-input w-32"
               placeholder="Interest Rate %"
             />

--- a/src/components/financial/CashflowSection.jsx
+++ b/src/components/financial/CashflowSection.jsx
@@ -214,6 +214,7 @@ const CashflowSection = ({ incomeSources = [], expenses = [], onIncomeChange, on
                 type="number"
                 value={source.amount}
                 onChange={(e) => handleIncomeUpdate(source.id, 'amount', e.target.value)}
+                onWheel={(e) => e.target.blur()}
                 className="form-input w-32"
                 placeholder="Amount"
               />
@@ -255,18 +256,19 @@ const CashflowSection = ({ incomeSources = [], expenses = [], onIncomeChange, on
                 </option>
               ))}
             </select>
-            <input
-              type="number"
-              value={newIncomeSource.amount}
-              onChange={(e) => {
-                setNewIncomeSource({ ...newIncomeSource, amount: e.target.value });
-                if (incomeErrors.amount && e.target.value) {
-                  setIncomeErrors(prev => ({ ...prev, amount: false }));
-                }
-              }}
-              className={`form-input w-32 ${incomeErrors.amount ? 'border-danger-300' : ''}`}
-              placeholder="Amount"
-            />
+              <input
+                type="number"
+                value={newIncomeSource.amount}
+                onChange={(e) => {
+                  setNewIncomeSource({ ...newIncomeSource, amount: e.target.value });
+                  if (incomeErrors.amount && e.target.value) {
+                    setIncomeErrors(prev => ({ ...prev, amount: false }));
+                  }
+                }}
+                onWheel={(e) => e.target.blur()}
+                className={`form-input w-32 ${incomeErrors.amount ? 'border-danger-300' : ''}`}
+                placeholder="Amount"
+              />
             <select
               value={newIncomeSource.frequency}
               onChange={(e) => setNewIncomeSource({...newIncomeSource, frequency: e.target.value})}
@@ -307,6 +309,7 @@ const CashflowSection = ({ incomeSources = [], expenses = [], onIncomeChange, on
                       type="number"
                       value={getExpenseAmount(category.id, item.id)}
                       onChange={(e) => handleExpenseChange(category.id, item.id, e.target.value)}
+                      onWheel={(e) => e.target.blur()}
                       className="form-input w-32"
                       placeholder="0"
                     />

--- a/src/components/financial/FinancialGoalsSection.jsx
+++ b/src/components/financial/FinancialGoalsSection.jsx
@@ -157,6 +157,7 @@ const FinancialGoalsSection = ({ goals = [], onGoalsChange }) => {
                         );
                         onGoalsChange(updated);
                       }}
+                      onWheel={(e) => e.target.blur()}
                       className="form-input mt-1"
                       placeholder="0"
                     />
@@ -172,6 +173,7 @@ const FinancialGoalsSection = ({ goals = [], onGoalsChange }) => {
                         );
                         onGoalsChange(updated);
                       }}
+                      onWheel={(e) => e.target.blur()}
                       className="form-input mt-1"
                       placeholder="0"
                     />
@@ -312,6 +314,7 @@ const FinancialGoalsSection = ({ goals = [], onGoalsChange }) => {
                 type="number"
                 value={newGoal.targetAmount}
                 onChange={(e) => setNewGoal({ ...newGoal, targetAmount: e.target.value })}
+                onWheel={(e) => e.target.blur()}
                 className="form-input"
                 placeholder="0"
               />
@@ -324,6 +327,7 @@ const FinancialGoalsSection = ({ goals = [], onGoalsChange }) => {
                 type="number"
                 value={newGoal.currentAmount}
                 onChange={(e) => setNewGoal({ ...newGoal, currentAmount: e.target.value })}
+                onWheel={(e) => e.target.blur()}
                 className="form-input"
                 placeholder="0"
               />

--- a/src/components/financial/InsuranceSection.jsx
+++ b/src/components/financial/InsuranceSection.jsx
@@ -157,6 +157,7 @@ const InsuranceSection = ({
                       type="number"
                       value={policy.coverageAmount}
                       onChange={(e) => handleUpdatePolicy(policy.id, 'coverageAmount', e.target.value)}
+                      onWheel={(e) => e.target.blur()}
                       className="form-input"
                     />
                   </td>
@@ -165,6 +166,7 @@ const InsuranceSection = ({
                       type="number"
                       value={policy.annualPremium}
                       onChange={(e) => handleUpdatePolicy(policy.id, 'annualPremium', e.target.value)}
+                      onWheel={(e) => e.target.blur()}
                       className="form-input"
                     />
                   </td>
@@ -224,6 +226,7 @@ const InsuranceSection = ({
               type="number"
               value={newPolicy.coverageAmount}
               onChange={(e) => setNewPolicy({...newPolicy, coverageAmount: e.target.value})}
+              onWheel={(e) => e.target.blur()}
               className="form-input"
               placeholder="Coverage Amount"
             />
@@ -231,6 +234,7 @@ const InsuranceSection = ({
               type="number"
               value={newPolicy.annualPremium}
               onChange={(e) => setNewPolicy({...newPolicy, annualPremium: e.target.value})}
+              onWheel={(e) => e.target.blur()}
               className="form-input"
               placeholder="Annual Premium"
             />
@@ -289,6 +293,7 @@ const InsuranceSection = ({
                   type="number"
                   value={needsCalculator.annualIncome}
                   onChange={(e) => handleCalculatorChange('annualIncome', e.target.value)}
+                  onWheel={(e) => e.target.blur()}
                   className="form-input"
                   placeholder="Annual income"
                 />
@@ -301,6 +306,7 @@ const InsuranceSection = ({
                   type="number"
                   value={needsCalculator.yearsToReplace}
                   onChange={(e) => handleCalculatorChange('yearsToReplace', e.target.value)}
+                  onWheel={(e) => e.target.blur()}
                   className="form-input"
                   placeholder="Years to replace"
                 />
@@ -313,6 +319,7 @@ const InsuranceSection = ({
                   type="number"
                   value={needsCalculator.finalExpenses}
                   onChange={(e) => handleCalculatorChange('finalExpenses', e.target.value)}
+                  onWheel={(e) => e.target.blur()}
                   className="form-input"
                   placeholder="Final expenses"
                 />
@@ -325,6 +332,7 @@ const InsuranceSection = ({
                   type="number"
                   value={needsCalculator.educationFund}
                   onChange={(e) => handleCalculatorChange('educationFund', e.target.value)}
+                  onWheel={(e) => e.target.blur()}
                   className="form-input"
                   placeholder="Education fund needed"
                 />
@@ -342,6 +350,7 @@ const InsuranceSection = ({
                   type="number"
                   value={needsCalculator.existingCoverage}
                   onChange={(e) => handleCalculatorChange('existingCoverage', e.target.value)}
+                  onWheel={(e) => e.target.blur()}
                   className="form-input"
                   placeholder="Existing coverage"
                 />
@@ -354,6 +363,7 @@ const InsuranceSection = ({
                   type="number"
                   value={needsCalculator.liquidAssets}
                   onChange={(e) => handleCalculatorChange('liquidAssets', e.target.value)}
+                  onWheel={(e) => e.target.blur()}
                   className="form-input"
                   placeholder="Liquid assets"
                 />
@@ -366,6 +376,7 @@ const InsuranceSection = ({
                   type="number"
                   value={needsCalculator.retirementAccounts}
                   onChange={(e) => handleCalculatorChange('retirementAccounts', e.target.value)}
+                  onWheel={(e) => e.target.blur()}
                   className="form-input"
                   placeholder="Retirement accounts"
                 />

--- a/src/components/forms/FinancialEvaluationForm.jsx
+++ b/src/components/forms/FinancialEvaluationForm.jsx
@@ -154,6 +154,7 @@ const FinancialEvaluationForm = ({
                 type="number"
                 value={item.amount}
                 onChange={(e) => updateIncomeItem(index, 'amount', e.target.value)}
+                onWheel={(e) => e.target.blur()}
                 className="form-input w-32"
                 placeholder="Amount"
                 min="0"
@@ -206,6 +207,7 @@ const FinancialEvaluationForm = ({
                 type="number"
                 value={item.amount}
                 onChange={(e) => updateExpenseItem(index, 'amount', e.target.value)}
+                onWheel={(e) => e.target.blur()}
                 className="form-input w-32"
                 placeholder="Amount"
                 min="0"


### PR DESCRIPTION
## Summary
- prevent mouse wheel from altering number inputs in financial forms
- update income and expense inputs to blur on wheel
- update asset and liability inputs to blur on wheel
- cover financial goal and insurance number inputs
- include evaluation form number inputs

## Testing
- `npm test --silent`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6887045ac1c083339df08aa1392c3fb7