### PR TITLE
Fix Supabase email redirect

### DIFF
--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -149,7 +149,7 @@ export const AuthProvider = ({ children }) => {
     const { data: result, error } = await supabase.auth.signUp({
       email,
       password,
-      options: { data },
+      options: { emailRedirectTo: `${window.location.origin}/login`, data },
     });
     
     if (error) throw error;

--- a/src/pages/AdminSignup.jsx
+++ b/src/pages/AdminSignup.jsx
@@ -117,6 +117,7 @@ const AdminSignup = () => {
         email: formData.email,
         password: formData.password,
         options: {
+          emailRedirectTo: `${window.location.origin}/login`,
           data: {
             firstName: formData.firstName,
             lastName: formData.lastName,

--- a/src/pages/Signup.jsx
+++ b/src/pages/Signup.jsx
@@ -100,6 +100,7 @@ const Signup = () => {
         email: formData.email,
         password: formData.password,
         options: {
+          emailRedirectTo: `${window.location.origin}/login`,
           data: {
             firstName: formData.firstName,
             lastName: formData.lastName,


### PR DESCRIPTION
## Summary
- ensure signUp redirects email confirmation back to `/login`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68870489ca2c8333bcb1ffe0a6c5cbdc