### PR TITLE
Improve financial form usability

### DIFF
--- a/src/components/financial/BalanceSheetSection.jsx
+++ b/src/components/financial/BalanceSheetSection.jsx
@@ -154,8 +154,9 @@ const BalanceSheetSection = ({ assets = [], liabilities = [], onAssetChange, onL
                 type="text"
                 value={liability.description}
                 onChange={(e) => handleUpdateLiability(liability.id, 'description', e.target.value)}
-                className="form-input flex-1"
+                className="form-input flex-1 md:w-60"
                 placeholder="Liability description"
+                maxLength={10}
               />
               <input
                 type="number"
@@ -201,8 +202,9 @@ const BalanceSheetSection = ({ assets = [], liabilities = [], onAssetChange, onL
               type="text"
               value={newLiability.description}
               onChange={(e) => setNewLiability({...newLiability, description: e.target.value})}
-              className="form-input flex-1"
+              className="form-input flex-1 md:w-60"
               placeholder="New liability"
+              maxLength={10}
             />
             <input
               type="number"

--- a/src/components/financial/CashflowSection.jsx
+++ b/src/components/financial/CashflowSection.jsx
@@ -240,6 +240,7 @@ const CashflowSection = ({ incomeSources = [], expenses = [], onIncomeChange, on
           <div className="flex items-center space-x-4">
             <select
               aria-label="Select Income Type"
+              required
               value={newIncomeSource.category}
               onChange={(e) => {
                 setNewIncomeSource({ ...newIncomeSource, category: e.target.value });
@@ -247,7 +248,7 @@ const CashflowSection = ({ incomeSources = [], expenses = [], onIncomeChange, on
                   setIncomeErrors(prev => ({ ...prev, category: false }));
                 }
               }}
-              className={`form-input flex-1 ${incomeErrors.category ? 'border-danger-300' : ''}`}
+              className={`form-input w-48 ${incomeErrors.category ? 'border-danger-300' : ''}`}
             >
               <option value="">Select Income Type</option>
               {INCOME_CATEGORIES.map(category => (
@@ -281,9 +282,9 @@ const CashflowSection = ({ incomeSources = [], expenses = [], onIncomeChange, on
             <button
               onClick={handleAddIncome}
               disabled={!newIncomeSource.category || !newIncomeSource.amount}
-              className={`p-2 text-primary-600 hover:bg-primary-50 rounded-lg transition-colors ${(!newIncomeSource.category || !newIncomeSource.amount) ? 'opacity-50 cursor-not-allowed' : ''}`}
+              className={`btn-primary ${(!newIncomeSource.category || !newIncomeSource.amount) ? 'opacity-50 cursor-not-allowed' : ''}`}
             >
-              <SafeIcon icon={FiPlus} className="w-4 h-4" />
+              Add Income
             </button>
             {(incomeErrors.category || incomeErrors.amount) && (
               <p className="text-danger-700 text-sm ml-2">Both fields are required</p>


### PR DESCRIPTION
## Summary
- enlarge income category selector and mark as required
- use `Add Income` button instead of icon
- widen liability description input and limit to 10 characters

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6887f677f3a48333886fb7dee686d9b3