### PR TITLE
Fix cashflow and liabilities fields

### DIFF
--- a/src/components/financial/BalanceSheetSection.jsx
+++ b/src/components/financial/BalanceSheetSection.jsx
@@ -154,7 +154,7 @@ const BalanceSheetSection = ({ assets = [], liabilities = [], onAssetChange, onL
                 type="text"
                 value={liability.description}
                 onChange={(e) => handleUpdateLiability(liability.id, 'description', e.target.value)}
-                className="form-input flex-1 md:w-60"
+                className="form-input flex-1 md:w-64"
                 placeholder="Liability description"
                 maxLength={10}
               />
@@ -202,7 +202,7 @@ const BalanceSheetSection = ({ assets = [], liabilities = [], onAssetChange, onL
               type="text"
               value={newLiability.description}
               onChange={(e) => setNewLiability({...newLiability, description: e.target.value})}
-              className="form-input flex-1 md:w-60"
+              className="form-input flex-1 md:w-64"
               placeholder="New liability"
               maxLength={10}
             />

--- a/src/components/financial/CashflowSection.jsx
+++ b/src/components/financial/CashflowSection.jsx
@@ -3,7 +3,7 @@ import { motion } from 'framer-motion';
 import SafeIcon from '../../common/SafeIcon';
 import * as FiIcons from 'react-icons/fi';
 
-const { FiPlus, FiTrash2, FiDollarSign } = FiIcons;
+const { FiTrash2 } = FiIcons;
 
 const INCOME_CATEGORIES = [
   { id: 'primary', label: 'Primary Income' },
@@ -248,9 +248,9 @@ const CashflowSection = ({ incomeSources = [], expenses = [], onIncomeChange, on
                   setIncomeErrors(prev => ({ ...prev, category: false }));
                 }
               }}
-              className={`form-input w-48 ${incomeErrors.category ? 'border-danger-300' : ''}`}
+              className={`form-input w-60 ${incomeErrors.category ? 'border-danger-300' : ''}`}
             >
-              <option value="">Select Income Type</option>
+              <option value="">Select Income Type *</option>
               {INCOME_CATEGORIES.map(category => (
                 <option key={category.id} value={category.id}>
                   {category.label}


### PR DESCRIPTION
## Summary
- enlarge income type selector and mark it required
- widen liability description inputs
- remove unused income icon import
- ensure tests pass

## Testing
- `npm run lint`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688812f41070833383a4804c7fa1ec7f