### PR TITLE
Prioritize featured strategies

### DIFF
--- a/src/pages/__tests__/StrategySelector.test.jsx
+++ b/src/pages/__tests__/StrategySelector.test.jsx
@@ -4,15 +4,17 @@ import '@testing-library/jest-dom';
 import { vi } from 'vitest';
 
 const strategiesData = [
-  { id: '1', name: 'Strategy A', description: 'Desc A', category: 'retirement', strategy_products_pf: [] },
-  { id: '2', name: 'Strategy B', description: 'Desc B', category: 'wealth_building', strategy_products_pf: [] }
+  { id: '1', name: 'Strategy A', description: 'Desc A', category: 'retirement', is_featured: true, strategy_products_pf: [] },
+  { id: '2', name: 'Strategy B', description: 'Desc B', category: 'wealth_building', is_featured: false, strategy_products_pf: [] }
 ];
 
 vi.mock('../../lib/supabaseClient', () => ({
   useSupabaseClient: () => ({
     from: () => ({
       select: () => ({
-        order: () => Promise.resolve({ data: strategiesData, error: null })
+        order: () => ({
+          order: () => Promise.resolve({ data: strategiesData, error: null })
+        })
       })
     })
   })


### PR DESCRIPTION
## Summary
- fetch the `is_featured` flag for strategies
- sort by featured status then name
- show a badge on featured strategies and render the top three first
- update unit test mocks for new query

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6888346edb0483339176162ce1c6ae55