### PR TITLE
Improve strategy selection UX

### DIFF
--- a/src/components/proposals/CarrierSelector.jsx
+++ b/src/components/proposals/CarrierSelector.jsx
@@ -116,7 +116,7 @@ const CarrierSelector = ({ selectedCarrier, onCarrierChange, selectedProduct }) 
             key={carrier.id}
             type="button"
             onClick={() => onCarrierChange(carrier.id)}
-            className={`p-4 text-left border-2 rounded-lg transition-all relative ${
+            className={`p-2 md:p-3 text-left border-2 rounded-lg transition-all relative ${
               selectedCarrier === carrier.id
                 ? 'border-primary-500 bg-primary-50'
                 : 'border-gray-200 hover:border-gray-300'

--- a/src/components/proposals/StrategySelector.jsx
+++ b/src/components/proposals/StrategySelector.jsx
@@ -176,7 +176,7 @@ const StrategySelector = ({ selectedStrategy, onStrategyChange, selectedProduct,
                 key={strategy.id}
                 type="button"
                 onClick={() => onStrategyChange(String(strategy.id))}
-                className={`p-4 text-left border-2 rounded-lg transition-all ${
+                className={`p-2 md:p-3 text-left border-2 rounded-lg transition-all ${
                   selectedStrategy === String(strategy.id)
                     ? 'border-primary-500 bg-primary-50'
                     : 'border-gray-200 hover:border-gray-300'
@@ -219,7 +219,7 @@ const StrategySelector = ({ selectedStrategy, onStrategyChange, selectedProduct,
                 key={product.id}
                 type="button"
                 onClick={() => onProductChange(String(product.id))}
-                className={`p-3 text-left border-2 rounded-lg transition-all ${
+                className={`p-2 md:p-3 text-left border-2 rounded-lg transition-all ${
                   selectedProduct === String(product.id)
                     ? 'border-primary-500 bg-primary-50'
                     : 'border-gray-200 hover:border-gray-300'

--- a/src/pages/ProposalManagement.jsx
+++ b/src/pages/ProposalManagement.jsx
@@ -155,6 +155,7 @@ const ProposalManagement = () => {
   const [selectedProposal, setSelectedProposal] = useState(null);
   const [searchTerm, setSearchTerm] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [selectedStrategyId, setSelectedStrategyId] = useState('');
 
   // Form state
   const [formData, setFormData] = useState({
@@ -286,6 +287,7 @@ const ProposalManagement = () => {
       lifetimeIncome: ''
     });
     setSelectedProposal(null);
+    setSelectedStrategyId('');
   };
 
   const handleEdit = (proposal) => {
@@ -312,6 +314,7 @@ const ProposalManagement = () => {
       tenYearIncome: proposal.tenYearIncome || '',
       lifetimeIncome: proposal.lifetimeIncome || ''
     });
+    setSelectedStrategyId(proposal.strategy ? String(proposal.strategy) : '');
     setIsEditModalOpen(true);
   };
 
@@ -625,15 +628,16 @@ const ProposalManagement = () => {
 
             {/* Strategy Selection */}
             <StrategySelector
-              selectedStrategy={formData.strategy}
-              onStrategyChange={(strategy) =>
+              selectedStrategy={selectedStrategyId}
+              onStrategyChange={(strategy) => {
+                setSelectedStrategyId(strategy);
                 setFormData((prev) => ({
                   ...prev,
                   strategy: strategy ? String(strategy) : '',
                   productType: '',
                   carrier: ''
-                }))
-              }
+                }));
+              }}
               selectedProduct={formData.productType}
               onProductChange={(productType) =>
                 setFormData((prev) => ({

--- a/src/pages/__tests__/StrategySelector.test.jsx
+++ b/src/pages/__tests__/StrategySelector.test.jsx
@@ -72,3 +72,20 @@ test('filters strategies by selected category', async () => {
   expect(screen.getByText('Strategy A')).toBeInTheDocument();
   expect(screen.queryByText('Strategy B')).toBeNull();
 });
+
+test('only the clicked card has selected styling', async () => {
+  render(<Wrapper onStrategyChange={() => {}} />);
+
+  await waitFor(() => screen.getByText('Strategy A'));
+
+  const cardA = screen.getByText('Strategy A').closest('button');
+  const cardB = screen.getByText('Strategy B').closest('button');
+
+  fireEvent.click(cardA);
+  await waitFor(() => expect(cardA.className).toContain('border-primary-500'));
+  expect(cardB.className).not.toContain('border-primary-500');
+
+  fireEvent.click(cardB);
+  await waitFor(() => expect(cardB.className).toContain('border-primary-500'));
+  expect(cardA.className).not.toContain('border-primary-500');
+});


### PR DESCRIPTION
## Summary
- shrink padding on strategy, product, and carrier cards for a tighter layout
- handle the selected strategy ID in ProposalManagement state
- add tests ensuring only the clicked strategy card is highlighted

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_688845a03d94833397a936a8be474165