### PR TITLE
Annualize income calc and add FIN unit test

### DIFF
--- a/src/pages/ClientFinancialReport.jsx
+++ b/src/pages/ClientFinancialReport.jsx
@@ -43,7 +43,16 @@ const ClientFinancialReport = () => {
       );
 
       // Process financial data for the report
-      const totalIncome = analysis.income_sources?.reduce((sum, source) => sum + parseFloat(source.amount || 0), 0) || 0;
+      const totalIncome =
+        analysis.income_sources?.reduce((sum, source) => {
+          const amount = parseFloat(source.amount || 0);
+          const annualAmount = {
+            monthly: amount * 12,
+            weekly: amount * 52,
+            annual: amount
+          }[source.frequency || 'monthly'];
+          return sum + annualAmount;
+        }, 0) || 0;
       const totalExpenses = analysis.expenses?.reduce((sum, expense) => sum + parseFloat(expense.amount || 0), 0) || 0;
       const netIncome = totalIncome - totalExpenses;
       
@@ -54,7 +63,7 @@ const ClientFinancialReport = () => {
       const totalInsuranceCoverage = analysis.insurance_policies?.reduce((sum, policy) => sum + parseFloat(policy.coverageAmount || 0), 0) || 0;
 
       // Calculate FIN (Financial Independence Number)
-      const financialIndependenceNumber = totalIncome * 25;
+      const financialIndependenceNumber = totalIncome * 20;
       
       setReportData({
         clientInfo: {

--- a/src/pages/__tests__/ClientFinancialReport.test.jsx
+++ b/src/pages/__tests__/ClientFinancialReport.test.jsx
@@ -1,0 +1,19 @@
+import { test, expect } from 'vitest';
+
+function calculateFIN(incomeSources) {
+  const totalIncome = incomeSources.reduce((sum, source) => {
+    const amount = parseFloat(source.amount || 0);
+    const annualAmount = {
+      monthly: amount * 12,
+      weekly: amount * 52,
+      annual: amount
+    }[source.frequency || 'monthly'];
+    return sum + annualAmount;
+  }, 0);
+  return totalIncome * 20;
+}
+
+test('monthly income of $5,000 results in FIN of $1,200,000', () => {
+  const fin = calculateFIN([{ amount: '5000', frequency: 'monthly' }]);
+  expect(fin).toBe(1200000);
+});


### PR DESCRIPTION
## Summary
- annualize income sources in financial report
- base Financial Independence Number on annual income times 20
- add FIN calculation unit test

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6889821deeb48333aba3fe98225146c6