### PR TITLE
Handle missing Supabase env vars gracefully

### DIFF
--- a/src/lib/__tests__/supabaseClient.test.js
+++ b/src/lib/__tests__/supabaseClient.test.js
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi } from 'vitest';
+
+const createClient = vi.fn();
+vi.mock('@supabase/supabase-js', () => ({ createClient }));
+
+describe('supabaseClient', () => {
+  it('returns stub when env vars are missing', async () => {
+    const originalUrl = process.env.VITE_SUPABASE_URL;
+    const originalKey = process.env.VITE_SUPABASE_ANON_KEY;
+    delete process.env.VITE_SUPABASE_URL;
+    delete process.env.VITE_SUPABASE_ANON_KEY;
+    vi.resetModules();
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { supabase } = await import('../supabaseClient');
+    expect(errorSpy).toHaveBeenCalled();
+    expect(createClient).not.toHaveBeenCalled();
+    expect(typeof supabase).toBe('function');
+    await expect(supabase.auth.getSession()).resolves.toEqual({});
+    errorSpy.mockRestore();
+    process.env.VITE_SUPABASE_URL = originalUrl;
+    process.env.VITE_SUPABASE_ANON_KEY = originalKey;
+  });
+});

--- a/src/lib/supabaseClient.js
+++ b/src/lib/supabaseClient.js
@@ -6,9 +6,24 @@ const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
 let supabaseInstance;
 
+function createStubClient() {
+  const stub = new Proxy(function () {}, {
+    get: () => stub,
+    apply: () => Promise.resolve({}),
+  });
+  return stub;
+}
+
 const getClient = () => {
   if (!supabaseInstance) {
-    supabaseInstance = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+    if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
+      console.error(
+        'Missing Supabase configuration. Set VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY.'
+      );
+      supabaseInstance = createStubClient();
+    } else {
+      supabaseInstance = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+    }
   }
   return supabaseInstance;
 };

--- a/src/services/__tests__/publitio.test.js
+++ b/src/services/__tests__/publitio.test.js
@@ -79,3 +79,14 @@ describe('deleteFile', () => {
     await expect(deleteFile('file123')).rejects.toThrow('bad');
   });
 });
+
+describe('environment validation', () => {
+  it('throws a controlled error when VITE_SUPABASE_URL is missing', async () => {
+    delete process.env.VITE_SUPABASE_URL;
+    vi.resetModules();
+    const { uploadFile } = await import('../publitio');
+    await expect(uploadFile(new File(['data'], 'test.txt'))).rejects.toThrow(
+      'VITE_SUPABASE_URL is not defined'
+    );
+  });
+});

--- a/src/services/publitio.js
+++ b/src/services/publitio.js
@@ -1,11 +1,22 @@
 import { supabase } from '../lib/supabaseClient';
 
-const baseUrl = import.meta.env.VITE_SUPABASE_URL
-  .replace('.supabase.co', '.functions.supabase.co') + '/publitio-proxy';
+function getBaseUrl() {
+  const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+  if (!supabaseUrl) {
+    throw new Error('VITE_SUPABASE_URL is not defined');
+  }
+  return (
+    supabaseUrl.replace('.supabase.co', '.functions.supabase.co') +
+    '/publitio-proxy'
+  );
+}
 
 export async function uploadFile(file, folder = '') {
   if (!file) throw new Error('File is required');
-  const { data: { session } } = await supabase.auth.getSession();
+  const baseUrl = getBaseUrl();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
   const token = session?.access_token;
   if (!token) throw new Error('Not authenticated');
 
@@ -30,7 +41,10 @@ export async function uploadFile(file, folder = '') {
 }
 
 export async function deleteFile(publicId) {
-  const { data: { session } } = await supabase.auth.getSession();
+  const baseUrl = getBaseUrl();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
   const token = session?.access_token;
   if (!token) throw new Error('Not authenticated');
   const url = `${baseUrl}?public_id=${encodeURIComponent(publicId)}`;


### PR DESCRIPTION
## Summary
- guard Supabase client creation by validating `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY`
- build Publitio base URL on demand with env check and controlled error
- add unit tests covering missing env variable scenarios

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_6894d1636a248333800bd49353b39d7e