### PR TITLE
refactor: centralize AuthProvider and add smoke test

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -28,7 +28,7 @@ import ProfileSettings from './pages/ProfileSettings';
 import ProjectionsSettings from './pages/ProjectionsSettings';
 import PrivateRoute from './components/auth/PrivateRoute';
 
-function App() {
+function AppContent() {
   const { loading, isSignedIn } = useAuth();
   const [authError, setAuthError] = useState(null);
 
@@ -76,11 +76,10 @@ function App() {
 
   // If signed in, wrap the app with our providers
   return (
-    <AuthProvider>
-      <CrmProvider>
-        <DataProvider>
-          <FinancialAnalysisProvider>
-            <Routes>
+    <CrmProvider>
+      <DataProvider>
+        <FinancialAnalysisProvider>
+          <Routes>
               <Route path="/" element={<Navigate to="/dashboard" replace />} />
               <Route path="/dashboard" element={<Dashboard />} />
               <Route
@@ -180,6 +179,13 @@ function App() {
           </FinancialAnalysisProvider>
         </DataProvider>
       </CrmProvider>
+  );
+}
+
+function App() {
+  return (
+    <AuthProvider>
+      <AppContent />
     </AuthProvider>
   );
 }

--- a/src/__tests__/AppSmoke.test.jsx
+++ b/src/__tests__/AppSmoke.test.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, it, expect, vi } from 'vitest';
+import { BrowserRouter } from 'react-router-dom';
+
+// Mock AuthContext to provide a basic auth state
+const mockAuthValue = { user: { id: '1', role: 'admin' }, loading: false, isSignedIn: true };
+vi.mock('../contexts/AuthContext', () => {
+  const React = require('react');
+  const AuthContext = React.createContext();
+  return {
+    AuthProvider: ({ children }) => (
+      <AuthContext.Provider value={mockAuthValue}>{children}</AuthContext.Provider>
+    ),
+    useAuthContext: () => React.useContext(AuthContext),
+  };
+});
+
+// Mock downstream providers to simple pass-through components
+vi.mock('../contexts/CrmContext', () => ({
+  CrmProvider: ({ children }) => <>{children}</>,
+}));
+vi.mock('../contexts/DataContext', () => ({
+  DataProvider: ({ children }) => <>{children}</>,
+}));
+vi.mock('../contexts/FinancialAnalysisContext', () => ({
+  FinancialAnalysisProvider: ({ children }) => <>{children}</>,
+}));
+
+import App from '../App';
+
+describe('App root rendering', () => {
+  it('renders without missing context errors', () => {
+    expect(() =>
+      render(
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      )
+    ).not.toThrow();
+  });
+});

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,17 +1,14 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
-import { AuthProvider } from './contexts/AuthContext';
 import App from './App';
 import './index.css';
 import './App.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <AuthProvider>
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>
-    </AuthProvider>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- Move AuthProvider out of entry point and into App component
- Ensure nested providers and hooks are wrapped by AuthProvider
- Add smoke test for rendering root without missing auth context

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68953720016c8333b1067b16c6aa5cb9