### PR TITLE
Add global ErrorBoundary for app initialization

### DIFF
--- a/src/components/ErrorBoundary.jsx
+++ b/src/components/ErrorBoundary.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import logError from '../utils/logError';
+
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error) {
+    logError('ErrorBoundary', error);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <div>Something went wrong.</div>;
+    }
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/src/components/__tests__/ErrorBoundary.test.jsx
+++ b/src/components/__tests__/ErrorBoundary.test.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+import ErrorBoundary from '../ErrorBoundary';
+
+function ProblemChild() {
+  React.useEffect(() => {
+    throw new Error('error');
+  }, []);
+  return <div>Loading...</div>;
+}
+
+describe('ErrorBoundary', () => {
+  it('renders fallback UI when a child throws', async () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(
+      <ErrorBoundary>
+        <ProblemChild />
+      </ErrorBoundary>
+    );
+
+    await waitFor(() => expect(screen.getByText('Something went wrong.')).toBeInTheDocument());
+    expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+
+    spy.mockRestore();
+  });
+});

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -5,13 +5,16 @@ import { AuthProvider } from './contexts/AuthContext';
 import App from './App';
 import './index.css';
 import './App.css';
+import ErrorBoundary from './components/ErrorBoundary';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <AuthProvider>
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>
-    </AuthProvider>
+    <ErrorBoundary>
+      <AuthProvider>
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </AuthProvider>
+    </ErrorBoundary>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- add reusable `ErrorBoundary` component that logs failures
- wrap `<App/>` with `<ErrorBoundary>` for safer startup
- test boundary renders fallback UI when children throw

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_6894d15ec1a88333a674a23955adaf76