### PR TITLE
Add image fallback and pre-render checks

### DIFF
--- a/src/components/layout/Navbar.jsx
+++ b/src/components/layout/Navbar.jsx
@@ -8,6 +8,7 @@ import SafeIcon from '../../common/SafeIcon';
 import * as FiIcons from 'react-icons/fi';
 import { getTransformedImage } from '../../services/publitio';
 import { getProfileImageUrl } from "../../utils/profileImage";
+import { DEFAULT_AVATAR_URL } from '../../utils/constants';
 
 const { FiLogOut, FiChevronDown, FiUser, FiSettings } = FiIcons;
 
@@ -29,6 +30,13 @@ const Navbar = () => {
     await signOut();
     navigate('/login');
   };
+
+  let profileImageSrc = DEFAULT_AVATAR_URL;
+  try {
+    profileImageSrc = getTransformedImage(getProfileImageUrl(user), { width: 64, height: 64 });
+  } catch (err) {
+    console.warn('Failed to process profile image', err);
+  }
 
   return (
     <nav className="bg-white shadow-soft border-b border-gray-100">
@@ -75,9 +83,14 @@ const Navbar = () => {
               className="flex items-center space-x-3 p-2 rounded-lg hover:bg-gray-50 transition-colors"
             >
               <img
-                src={getTransformedImage(getProfileImageUrl(user), { width: 64, height: 64 })}
+                src={profileImageSrc}
                 alt={user?.fullName || 'User'}
                 className="w-8 h-8 rounded-full object-cover"
+                onError={(e) => {
+                  e.currentTarget.onerror = null;
+                  console.warn('Profile image failed to load, using default.');
+                  e.currentTarget.src = DEFAULT_AVATAR_URL;
+                }}
               />
               <div className="hidden md:block text-left">
                 <p className="text-sm font-medium text-gray-900">{user?.fullName || 'User'}</p>

--- a/src/pages/ClientFinancialReport.jsx
+++ b/src/pages/ClientFinancialReport.jsx
@@ -11,6 +11,7 @@ import Navbar from '../components/layout/Navbar';
 import LoadingSpinner from '../components/ui/LoadingSpinner';
 import SafeIcon from '../common/SafeIcon';
 import * as FiIcons from 'react-icons/fi';
+import { DEFAULT_AVATAR_URL } from '../utils/constants';
 
 ChartJS.register(ArcElement, Tooltip, Legend, CategoryScale, LinearScale, BarElement, Title);
 
@@ -162,6 +163,18 @@ const ClientFinancialReport = () => {
 
     for (const section of sections) {
       console.log('Processing section:', section.id, section);
+      // Ensure images in the section are loaded
+      const imgs = section.querySelectorAll('img');
+      for (const img of imgs) {
+        if (!(img.complete && img.naturalWidth > 0)) {
+          console.warn('Image not loaded, using fallback before rendering PDF:', img.src);
+          img.src = DEFAULT_AVATAR_URL;
+          await new Promise(resolve => {
+            img.onload = resolve;
+            img.onerror = resolve;
+          });
+        }
+      }
       // Convert section to image
       const canvas = await html2canvas(section, {
         scale: 1.5,


### PR DESCRIPTION
## Summary
- Load DEFAULT_AVATAR_URL and use it as a fallback for profile images in the navbar
- Ensure each image in report sections is loaded or replaced before html2canvas conversion

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689622c1d3d083339a24f1d888fb815e