### PR TITLE
Add willReadFrequently option for PDF rendering

### DIFF
--- a/src/pages/ClientFinancialReport.jsx
+++ b/src/pages/ClientFinancialReport.jsx
@@ -183,6 +183,7 @@ const ClientFinancialReport = () => {
         logging: false,
         backgroundColor: '#ffffff',
         imageTimeout: 0,
+        willReadFrequently: true,
         windowWidth: section.scrollWidth,
         windowHeight: section.scrollHeight,
         onclone: clonedDoc => {


### PR DESCRIPTION
## Summary
- optimize html2canvas usage in ClientFinancialReport by enabling `willReadFrequently`

## Testing
- `npm test`
- `npm run lint`
- (attempted) headless pdf generation via html2canvas; failed due to missing DOM features

------
https://chatgpt.com/codex/tasks/task_e_689a85bc1c488333887de732db64072a