### PR TITLE
Add foreignObjectRendering flag to PDF export

### DIFF
--- a/src/pages/ClientFinancialReport.jsx
+++ b/src/pages/ClientFinancialReport.jsx
@@ -187,6 +187,7 @@ const ClientFinancialReport = () => {
         scale: 1.5,
         useCORS: true,
         allowTaint: false,
+        foreignObjectRendering: false,
         logging: false,
         backgroundColor: '#ffffff',
         imageTimeout: 0,


### PR DESCRIPTION
## Summary
- add `foreignObjectRendering: false` to html2canvas when exporting client financial report to PDF

## Testing
- `npx vitest run`
- ⚠️ attempted PDF generation using headless browser but missing libatk-bridge-2.0.so.0 (environment limitation)


------
https://chatgpt.com/codex/tasks/task_e_689bbc7d05308333a34cd087d542912b