### PR TITLE
chore: enforce minimum PDF font size

### DIFF
--- a/src/pages/ClientFinancialReport.jsx
+++ b/src/pages/ClientFinancialReport.jsx
@@ -18,13 +18,26 @@ ChartJS.register(ArcElement, Tooltip, Legend, CategoryScale, LinearScale, BarEle
 const inlineStylesRecursively = (node) => {
   if (!node || node.nodeType !== 1) return;
   const computedStyle = window.getComputedStyle(node);
+  const originalFontSize = computedStyle.fontSize;
   Array.from(computedStyle).forEach((prop) => {
     node.style.setProperty(prop, computedStyle.getPropertyValue(prop));
   });
-  const fontSize = parseFloat(computedStyle.fontSize);
-  if (!isNaN(fontSize) && fontSize < 12) {
-    node.style.fontSize = '12px';
+  const fontSize = parseFloat(originalFontSize);
+  if (!isNaN(fontSize)) {
+    if (fontSize < 12) {
+      node.style.fontSize = '12px';
+    } else {
+      node.style.fontSize = originalFontSize;
+    }
   }
+  const tailwindFontMap = {
+    'text-3xl': '30px',
+    'text-4xl': '36px',
+    'text-5xl': '48px'
+  };
+  Object.entries(tailwindFontMap).forEach(([cls, size]) => {
+    if (node.classList.contains(cls)) node.style.fontSize = size;
+  });
   node.childNodes.forEach(child => inlineStylesRecursively(child));
 };
 


### PR DESCRIPTION
## Summary
- ensure inline styles keep original font sizes and enforce a 12px minimum
- map selected Tailwind font utilities to fixed pixel sizes before PDF generation

## Testing
- `npx vitest run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e4d4caa988333b3f3c2f84165f520