### PR TITLE
Add debug logs to inlineStylesRecursively

### DIFF
--- a/src/pages/ClientFinancialReport.jsx
+++ b/src/pages/ClientFinancialReport.jsx
@@ -19,6 +19,7 @@ const debugInlineStyles = import.meta.env.VITE_DEBUG_STYLES === 'true';
 
 const inlineStylesRecursively = (node, sectionType = 'body') => {
   if (!node || node.nodeType !== 1) return;
+  console.log('inlineStylesRecursively start', node.tagName, { sectionType });
   const computedStyle = window.getComputedStyle(node);
   if (debugInlineStyles) {
     logDev(
@@ -73,6 +74,8 @@ const inlineStylesRecursively = (node, sectionType = 'body') => {
       node.style.fontSize = '12px';
     }
   }
+
+  console.log('inlineStylesRecursively applied', node.tagName, node.style.fontSize);
 
   if (debugInlineStyles) {
     logDev(


### PR DESCRIPTION
## Summary
- log recursive start and section type for inline styling
- log applied font size for each node

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689fa3e677848333883ccf1fc1b829b0