### PR TITLE
Force FIN elements to use 48px font size

### DIFF
--- a/src/pages/ClientFinancialReport.jsx
+++ b/src/pages/ClientFinancialReport.jsx
@@ -55,6 +55,11 @@ const inlineStylesRecursively = (node, sectionType = 'body') => {
 
   const textContent = node.textContent || '';
 
+  if (node.textContent.includes('$') && node.textContent.includes(',000')) {
+    node.style.fontSize = '48px';
+    console.log('FIN element forced to 48px', node.textContent);
+  }
+
   if (sectionType === 'header') {
     if (/\$[\d,]+/.test(textContent)) {
       node.style.fontSize = '48px';


### PR DESCRIPTION
## Summary
- enforce 48px font size for elements containing `$` and `,000` in ClientFinancialReport

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_689fc2039b408333836e278cdd4aaf80