### PR TITLE
Fix FIN amount sizing in report header

### DIFF
--- a/src/pages/ClientFinancialReport.jsx
+++ b/src/pages/ClientFinancialReport.jsx
@@ -55,13 +55,15 @@ const inlineStylesRecursively = (node, sectionType = 'body') => {
 
   const textContent = node.textContent || '';
 
-  if (node.textContent.includes('$') && node.textContent.includes(',000')) {
-    node.style.fontSize = '48px';
-    console.log('FIN element forced to 48px', node.textContent);
-  }
-
   if (sectionType === 'header') {
-    if (/\$[\d,]+/.test(textContent)) {
+    const finAmountRegex = /^\s*\$[\d,]+(?:\.\d{2})?\s*$/;
+    const finLabelRegex = /financial independence number/i;
+    const isFinAmount = finAmountRegex.test(textContent);
+    const hasFinLabel =
+      finLabelRegex.test(node.previousElementSibling?.textContent || '') ||
+      finLabelRegex.test(node.parentElement?.textContent || '');
+
+    if (isFinAmount && hasFinLabel) {
       node.style.fontSize = '48px';
     } else if (node.tagName === 'H1') {
       node.style.fontSize = '28px';


### PR DESCRIPTION
## Summary
- ensure FIN override applies only to elements containing just the currency amount
- limit FIN sizing to header and keep standard header font sizes

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689fcd0cbfbc8333bbbcc4d7ff989102