### PR TITLE
Ensure hero page stands alone in client financial report

### DIFF
--- a/src/pages/ClientFinancialReport.jsx
+++ b/src/pages/ClientFinancialReport.jsx
@@ -700,7 +700,9 @@ const ClientFinancialReport = () => {
                   </div>
 
                   {/* Cover Letter / FIN */}
+                  <div style={{ pageBreakAfter: 'always' }}>
                     <HeroSection fin={reportData.clientInfo.fin} clientName={reportData.clientInfo.name} />
+                  </div>
                 </div>
               )}
             </div>


### PR DESCRIPTION
## Summary
- Wrap `HeroSection` in `ClientFinancialReport` with a div having `pageBreakAfter: 'always'` so content that follows renders on a new page in generated PDFs.

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a02906e3b883338cc48be03ace755d