### PR TITLE
test: verify hero and fin font sizes

### DIFF
--- a/src/pages/ClientFinancialReport.jsx
+++ b/src/pages/ClientFinancialReport.jsx
@@ -18,7 +18,7 @@ ChartJS.register(ArcElement, Tooltip, Legend, CategoryScale, LinearScale, BarEle
 
 const debugInlineStyles = import.meta.env.VITE_DEBUG_STYLES === 'true';
 
-const inlineStylesRecursively = (node, sectionType = 'body') => {
+export const inlineStylesRecursively = (node, sectionType = 'body') => {
   if (!node || node.nodeType !== 1) return;
   console.log('inlineStylesRecursively start', node.tagName, { sectionType });
   const computedStyle = window.getComputedStyle(node);

--- a/src/pages/__tests__/HeroFontSizes.test.jsx
+++ b/src/pages/__tests__/HeroFontSizes.test.jsx
@@ -1,0 +1,19 @@
+import { test, expect } from 'vitest';
+import { JSDOM } from 'jsdom';
+import { inlineStylesRecursively } from '../ClientFinancialReport.jsx';
+
+test('hero heading and FIN amount use expected font sizes', () => {
+  const dom = new JSDOM(`
+    <div id="hero">
+      <h1 class="text-6xl">Your Financial Independence</h1>
+      <p>Financial Independence Number</p>
+      <p class="text-7xl">$1,234,567</p>
+    </div>
+  `);
+  const hero = dom.window.document.getElementById('hero');
+  inlineStylesRecursively(hero, 'header');
+  const heading = hero.querySelector('h1');
+  const finAmount = hero.querySelectorAll('p')[1];
+  expect(heading.style.fontSize).toBe('64px');
+  expect(finAmount.style.fontSize).toBe('72px');
+});


### PR DESCRIPTION
## Summary
- export inlineStylesRecursively for testing
- add unit test ensuring hero heading and FIN amount are inlined at 64px and 72px during PDF export

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0d04ece5c8333b2c05a96913909a2