### PR TITLE
Add id to hero section for PDF export

### DIFF
--- a/src/pages/ClientFinancialReport.jsx
+++ b/src/pages/ClientFinancialReport.jsx
@@ -658,7 +658,11 @@ const ClientFinancialReport = () => {
           {/* Financial Report Content */}
           <div id="financial-report" className="space-y-8">
             {reportData && (
-              <div className="w-full" style={{ pageBreakAfter: 'always' }}>
+              <div
+                id="hero-section"
+                className="w-full"
+                style={{ pageBreakAfter: 'always' }}
+              >
                 <HeroSection
                   fin={reportData.clientInfo.fin}
                   clientName={reportData.clientInfo.name}


### PR DESCRIPTION
## Summary
- add `hero-section` id to ClientFinancialReport hero container so it can be selected during PDF generation

## Testing
- `npm test -- --run`
- `node test_pdf_export` (inline script) verifying hero section processed first and PDF has 1 page


------
https://chatgpt.com/codex/tasks/task_e_68a109fb18a88333b4bdecf52f7fe306