### PR TITLE
Reorder financial report summary section

### DIFF
--- a/src/components/financial/HeroSection.jsx
+++ b/src/components/financial/HeroSection.jsx
@@ -10,7 +10,7 @@ const HeroSection = ({ fin, clientName }) => {
     }).format(amount);
 
   return (
-    <div className="min-h-screen flex flex-col justify-center items-center text-center p-10 space-y-6 bg-gradient-to-r from-primary-50 to-secondary-100">
+    <div className="text-center space-y-6">
       <h1 className="text-6xl font-semibold text-gray-900">Your Financial Independence</h1>
       <p className="text-2xl text-gray-800">Dear {clientName},</p>
       <p className="text-2xl text-gray-800">

--- a/src/pages/ClientFinancialReport.jsx
+++ b/src/pages/ClientFinancialReport.jsx
@@ -657,19 +657,6 @@ const ClientFinancialReport = () => {
 
           {/* Financial Report Content */}
           <div id="financial-report" className="space-y-8">
-            {reportData && (
-              <div
-                id="hero-section"
-                className="w-full"
-                style={{ pageBreakAfter: 'always' }}
-              >
-                <HeroSection
-                  fin={reportData.clientInfo.fin}
-                  clientName={reportData.clientInfo.name}
-                />
-              </div>
-            )}
-
             {/* Report Header */}
             <div
               id="report-header"
@@ -733,6 +720,19 @@ const ClientFinancialReport = () => {
                 </div>
               )}
             </div>
+
+            {reportData && (
+              <div
+                id="fin-summary"
+                className="bg-white rounded-xl shadow-soft border border-gray-100 p-8 print:border-0 print:shadow-none"
+                style={{ pageBreakAfter: 'always' }}
+              >
+                <HeroSection
+                  fin={reportData.clientInfo.fin}
+                  clientName={reportData.clientInfo.name}
+                />
+              </div>
+            )}
 
             {/* Cashflow Summary */}
             {reportData && (


### PR DESCRIPTION
## Summary
- Move hero section after report header in financial report, rename to `fin-summary`, and apply standard section styles.
- Simplify HeroSection layout by removing gradient background and extra padding for consistent styling.

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1169ab2d48333963285e7be2e4b2c