### PR TITLE
Refactor hero section to financial summary

### DIFF
--- a/src/components/financial/FinancialIndependenceSummary.jsx
+++ b/src/components/financial/FinancialIndependenceSummary.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-const HeroSection = ({ fin, clientName }) => {
+const FinancialIndependenceSummary = ({ fin, clientName }) => {
   const formatCurrency = (amount) =>
     new Intl.NumberFormat('en-US', {
       style: 'currency',
@@ -11,13 +11,13 @@ const HeroSection = ({ fin, clientName }) => {
 
   return (
     <div className="text-center space-y-6">
-      <h1 className="text-6xl font-semibold text-gray-900">Your Financial Independence</h1>
+      <h2 className="text-3xl font-semibold text-gray-900">Your Financial Independence</h2>
       <p className="text-2xl text-gray-800">Dear {clientName},</p>
       <p className="text-2xl text-gray-800">
         Based on your current financial situation, we've calculated your Financial Independence Number (FIN) - the amount needed
         to support your lifestyle indefinitely:
       </p>
-      <p className="text-7xl font-bold text-primary-600">{formatCurrency(fin)}</p>
+      <p className="text-5xl font-bold text-primary-600">{formatCurrency(fin)}</p>
       <p className="text-2xl text-gray-800">
         This report provides a comprehensive overview of your current financial position and identifies opportunities to help you
         achieve financial independence.
@@ -26,4 +26,4 @@ const HeroSection = ({ fin, clientName }) => {
   );
 };
 
-export default HeroSection;
+export default FinancialIndependenceSummary;

--- a/src/pages/ClientFinancialReport.jsx
+++ b/src/pages/ClientFinancialReport.jsx
@@ -8,7 +8,7 @@ import jsPDF from 'jspdf';
 import html2canvas from 'html2canvas';
 import Navbar from '../components/layout/Navbar';
 import LoadingSpinner from '../components/ui/LoadingSpinner';
-import HeroSection from '../components/financial/HeroSection';
+import FinancialIndependenceSummary from '../components/financial/FinancialIndependenceSummary';
 import SafeIcon from '../common/SafeIcon';
 import * as FiIcons from 'react-icons/fi';
 import { DEFAULT_AVATAR_URL } from '../utils/constants';
@@ -114,8 +114,8 @@ export const inlineStylesRecursively = (node, sectionType = 'body') => {
       } else if (largeTextClassSize) {
         node.style.fontSize = largeTextClassSize;
       } else if (['H1', 'H2', 'H3', 'H4', 'H5', 'H6'].includes(node.tagName)) {
-        const currentSize = parseFloat(node.style.fontSize) || originalFontSize || 48;
-        node.style.fontSize = `${Math.max(currentSize, 48)}px`;
+        const currentSize = parseFloat(node.style.fontSize) || originalFontSize || 30;
+        node.style.fontSize = `${Math.max(currentSize, 30)}px`;
       } else if (node.tagName === 'P') {
         const currentSize = parseFloat(node.style.fontSize) || originalFontSize || 24;
         node.style.fontSize = `${Math.max(currentSize, 24)}px`;
@@ -727,7 +727,7 @@ const ClientFinancialReport = () => {
                 className="bg-white rounded-xl shadow-soft border border-gray-100 p-8 print:border-0 print:shadow-none"
                 style={{ pageBreakAfter: 'always' }}
               >
-                <HeroSection
+                <FinancialIndependenceSummary
                   fin={reportData.clientInfo.fin}
                   clientName={reportData.clientInfo.name}
                 />

--- a/src/pages/__tests__/HeroFontSizes.test.jsx
+++ b/src/pages/__tests__/HeroFontSizes.test.jsx
@@ -5,15 +5,15 @@ import { inlineStylesRecursively } from '../ClientFinancialReport.jsx';
 test('hero heading and FIN amount use expected font sizes', () => {
   const dom = new JSDOM(`
     <div id="hero">
-      <h1 class="text-6xl">Your Financial Independence</h1>
+      <h2 class="text-3xl">Your Financial Independence</h2>
       <p>Financial Independence Number</p>
-      <p class="text-7xl">$1,234,567</p>
+      <p class="text-5xl">$1,234,567</p>
     </div>
   `);
   const hero = dom.window.document.getElementById('hero');
   inlineStylesRecursively(hero, 'header');
-  const heading = hero.querySelector('h1');
+  const heading = hero.querySelector('h2');
   const finAmount = hero.querySelectorAll('p')[1];
-  expect(heading.style.fontSize).toBe('64px');
-  expect(finAmount.style.fontSize).toBe('72px');
+  expect(heading.style.fontSize).toBe('30px');
+  expect(finAmount.style.fontSize).toBe('48px');
 });


### PR DESCRIPTION
## Summary
- rename HeroSection to FinancialIndependenceSummary
- shrink hero heading to h2 with smaller fonts
- update inline style logic and unit tests

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68a152a6f7248333b31790855cb4bbf9