### PR TITLE
Clarify financial independence number calculation

### DIFF
--- a/src/pages/ClientFinancialReport.jsx
+++ b/src/pages/ClientFinancialReport.jsx
@@ -13,6 +13,7 @@ import SafeIcon from '../common/SafeIcon';
 import * as FiIcons from 'react-icons/fi';
 import { DEFAULT_AVATAR_URL } from '../utils/constants';
 import logDev from '../utils/logDev';
+import { calculateTotalAnnualIncome, calculateFinancialIndependenceNumber } from '../utils/financial';
 
 ChartJS.register(ArcElement, Tooltip, Legend, CategoryScale, LinearScale, BarElement, Title, PieController, BarController);
 
@@ -188,16 +189,7 @@ const ClientFinancialReport = () => {
       );
 
       // Process financial data for the report
-      const totalIncome =
-        analysis.income_sources?.reduce((sum, source) => {
-          const amount = parseFloat(source.amount || 0);
-          const annualAmount = {
-            monthly: amount * 12,
-            weekly: amount * 52,
-            annual: amount
-          }[source.frequency || 'monthly'];
-          return sum + annualAmount;
-        }, 0) || 0;
+      const totalIncome = calculateTotalAnnualIncome(analysis.income_sources);
       const totalExpenses = analysis.expenses?.reduce((sum, expense) => sum + parseFloat(expense.amount || 0), 0) || 0;
       const netIncome = totalIncome - totalExpenses;
       
@@ -208,7 +200,10 @@ const ClientFinancialReport = () => {
       const totalInsuranceCoverage = analysis.insurance_policies?.reduce((sum, policy) => sum + parseFloat(policy.coverageAmount || 0), 0) || 0;
 
       // Calculate FIN (Financial Independence Number)
-      const financialIndependenceNumber = totalIncome * 20;
+      // The FIN follows the 4% rule: 20× total annual income
+      const financialIndependenceNumber = calculateFinancialIndependenceNumber(
+        analysis.income_sources
+      );
       
       setReportData({
         clientInfo: {

--- a/src/pages/__tests__/ClientFinancialReport.test.jsx
+++ b/src/pages/__tests__/ClientFinancialReport.test.jsx
@@ -1,19 +1,23 @@
 import { test, expect } from 'vitest';
-
-function calculateFIN(incomeSources) {
-  const totalIncome = incomeSources.reduce((sum, source) => {
-    const amount = parseFloat(source.amount || 0);
-    const annualAmount = {
-      monthly: amount * 12,
-      weekly: amount * 52,
-      annual: amount
-    }[source.frequency || 'monthly'];
-    return sum + annualAmount;
-  }, 0);
-  return totalIncome * 20;
-}
+import {
+  calculateFinancialIndependenceNumber,
+  calculateTotalAnnualIncome,
+} from '../../utils/financial';
 
 test('monthly income of $5,000 results in FIN of $1,200,000', () => {
-  const fin = calculateFIN([{ amount: '5000', frequency: 'monthly' }]);
-  expect(fin).toBe(1200000);
+  const sources = [{ amount: '5000', frequency: 'monthly' }];
+  const annual = calculateTotalAnnualIncome(sources);
+  expect(calculateFinancialIndependenceNumber(sources)).toBe(annual * 20);
+  expect(calculateFinancialIndependenceNumber(sources)).toBe(1200000);
+});
+
+test('mixed income sources produce FIN equal to 20× annual income', () => {
+  const sources = [
+    { amount: '5000', frequency: 'monthly' },
+    { amount: '600', frequency: 'weekly' },
+    { amount: '10000', frequency: 'annual' },
+  ];
+  const annual = calculateTotalAnnualIncome(sources);
+  expect(annual).toBe(101200);
+  expect(calculateFinancialIndependenceNumber(sources)).toBe(annual * 20);
 });

--- a/src/utils/financial.js
+++ b/src/utils/financial.js
@@ -1,0 +1,27 @@
+export function annualizeIncome(amount, frequency = 'monthly') {
+  const amt = parseFloat(amount) || 0;
+  const freq = (frequency || 'monthly').toLowerCase();
+  switch (freq) {
+    case 'weekly':
+      return amt * 52;
+    case 'annual':
+    case 'yearly':
+      return amt;
+    case 'monthly':
+    default:
+      return amt * 12;
+  }
+}
+
+export function calculateTotalAnnualIncome(incomeSources = []) {
+  return incomeSources.reduce(
+    (sum, source) => sum + annualizeIncome(source.amount, source.frequency),
+    0
+  );
+}
+
+export function calculateFinancialIndependenceNumber(incomeSources = []) {
+  // FIN is defined as 20× total annual income (inverse of the 4% rule)
+  const totalIncome = calculateTotalAnnualIncome(incomeSources);
+  return totalIncome * 20;
+}


### PR DESCRIPTION
## Summary
- centralize income annualization and FIN math in `src/utils/financial.js`
- compute client report income/FIN using shared helpers with clear 20× comment
- test mixed-frequency income sources to assert FIN equals 20× annual income

## Testing
- `npm run lint`
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68a161dd52988333b338b38ee33ba13b