### PR TITLE
fix font sizing defaults

### DIFF
--- a/src/pages/ClientFinancialReport.jsx
+++ b/src/pages/ClientFinancialReport.jsx
@@ -126,11 +126,13 @@ export const inlineStylesRecursively = (node, sectionType = 'body') => {
       }
     } else {
       if (['H1', 'H2', 'H3'].includes(node.tagName)) {
-        node.style.fontSize = '16px';
+        node.style.fontSize = !isNaN(originalFontSize)
+          ? `${Math.max(originalFontSize, 24)}px`
+          : '24px';
       } else if (!isNaN(originalFontSize)) {
-        node.style.fontSize = `${Math.min(originalFontSize * 1.2, 12)}px`;
+        node.style.fontSize = `${Math.max(originalFontSize, 14)}px`;
       } else {
-        node.style.fontSize = '12px';
+        node.style.fontSize = '14px';
       }
     }
   }

--- a/src/pages/__tests__/HeroFontSizes.test.jsx
+++ b/src/pages/__tests__/HeroFontSizes.test.jsx
@@ -13,7 +13,24 @@ test('hero heading and FIN amount use expected font sizes', () => {
   const hero = dom.window.document.getElementById('hero');
   inlineStylesRecursively(hero, 'header');
   const heading = hero.querySelector('h2');
+  const label = hero.querySelectorAll('p')[0];
   const finAmount = hero.querySelectorAll('p')[1];
   expect(heading.style.fontSize).toBe('30px');
+  expect(label.style.fontSize).toBe('24px');
   expect(finAmount.style.fontSize).toBe('48px');
+});
+
+test('body heading and paragraph use new defaults', () => {
+  const dom = new JSDOM(`
+    <div id="content">
+      <h2>Section Heading</h2>
+      <p>Some paragraph</p>
+    </div>
+  `);
+  const content = dom.window.document.getElementById('content');
+  inlineStylesRecursively(content);
+  const heading = content.querySelector('h2');
+  const paragraph = content.querySelector('p');
+  expect(heading.style.fontSize).toBe('24px');
+  expect(paragraph.style.fontSize).toBe('14px');
 });


### PR DESCRIPTION
## Summary
- ensure inline font sizing preserves computed size
- use larger defaults for body headings and text
- update font-size tests for new defaults

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a23c33e1dc833397197d2464fd5828