### PR TITLE
Flag FIN summary section as header

### DIFF
--- a/src/pages/ClientFinancialReport.jsx
+++ b/src/pages/ClientFinancialReport.jsx
@@ -332,6 +332,12 @@ const ClientFinancialReport = () => {
         } else if (originalSection.classList?.contains('report-header')) {
           isHeader = true;
           headerReason = "classList contains 'report-header'";
+        } else if (
+          originalSection.id === 'fin-summary' ||
+          originalSection.classList?.contains('fin-summary')
+        ) {
+          isHeader = true;
+          headerReason = "id/class indicates 'fin-summary'";
         } else if (sections[0] === originalSection) {
           isHeader = true;
           headerReason = 'first section';


### PR DESCRIPTION
## Summary
- treat `#fin-summary` section as a `header` during section type detection so it uses header styling when inlining styles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2471dbea083338114b4a39a5355c7