### PR TITLE
style: enlarge FIN summary spacing

### DIFF
--- a/src/components/financial/FinancialIndependenceSummary.jsx
+++ b/src/components/financial/FinancialIndependenceSummary.jsx
@@ -10,7 +10,7 @@ const FinancialIndependenceSummary = ({ fin, clientName }) => {
     }).format(amount);
 
   return (
-    <div className="text-center space-y-6">
+    <div className="text-center space-y-8">
       <h2 className="text-xl font-semibold text-gray-900">Your Financial Independence</h2>
       <p className="text-base text-gray-800">Dear {clientName},</p>
       <p className="text-sm text-gray-800">
@@ -18,7 +18,10 @@ const FinancialIndependenceSummary = ({ fin, clientName }) => {
         to support your lifestyle indefinitely:
       </p>
       {/* Emphasized FIN amount */}
-      <p className="text-xl text-[18px] font-bold text-primary-600 inline-block border-b border-gray-300 pb-1">
+      <p
+        style={{ fontSize: '60px', padding: '20px 0' }}
+        className="font-bold text-primary-600 inline-block border-b border-gray-300"
+      >
         {formatCurrency(fin)}
       </p>
     </div>

--- a/src/pages/ClientFinancialReport.jsx
+++ b/src/pages/ClientFinancialReport.jsx
@@ -678,7 +678,7 @@ const ClientFinancialReport = () => {
             {reportData && (
               <div
                 id="fin-summary"
-                className="bg-white rounded-xl shadow-soft border border-gray-100 p-8 print:border-0 print:shadow-none mt-8"
+                className="bg-white rounded-xl shadow-soft border border-gray-100 p-12 print:border-0 print:shadow-none mt-8"
                 style={{ pageBreakBefore: 'always', breakInside: 'avoid' }}
               >
                 <FinancialIndependenceSummary

--- a/src/pages/__tests__/HeroFontSizes.test.jsx
+++ b/src/pages/__tests__/HeroFontSizes.test.jsx
@@ -56,7 +56,7 @@ test('client-info elements use Tailwind font sizes', () => {
   expect(detail.style.fontSize).toBe('14px');
 });
 
-test('FIN summary key elements share font size', () => {
+test('FIN amount displays with enlarged font size', () => {
   const style = document.createElement('style');
   style.textContent = '.text-xl{font-size:18px}.text-base{font-size:18px}';
   document.head.appendChild(style);
@@ -69,7 +69,7 @@ test('FIN summary key elements share font size', () => {
   const expected = getComputedStyle(title).fontSize;
   expect(expected).toBe('18px');
   expect(getComputedStyle(clientHeading).fontSize).toBe(expected);
-  expect(getComputedStyle(finAmount).fontSize).toBe(expected);
+  expect(getComputedStyle(finAmount).fontSize).toBe('60px');
 });
 
 test('cover sections render with consistent font sizes', () => {


### PR DESCRIPTION
## Summary
- increase FIN summary container padding for better vertical spacing
- emphasize Financial Independence Number with larger font and padding
- update test expectations for new FIN amount styling

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a3de5debac83338976918fa93d1232