### PR TITLE
Scale first sections when generating PDF

### DIFF
--- a/src/pages/ClientFinancialReport.jsx
+++ b/src/pages/ClientFinancialReport.jsx
@@ -271,6 +271,7 @@ const ClientFinancialReport = () => {
         }
         const originalSection = sec.current || sec;
         logDev('Processing section:', originalSection.id, originalSection);
+        const scaleFactor = index < 2 ? 0.75 : 1;
 
         let isHeader = false;
         let headerReason = '';
@@ -314,13 +315,18 @@ const ClientFinancialReport = () => {
         clonedSection.style.position = 'absolute';
         clonedSection.style.left = '-10000px';
         document.body.appendChild(clonedSection);
+        if (index < 2) {
+          clonedSection.style.transform = 'scale(0.75)';
+          clonedSection.style.transformOrigin = 'top left';
+          clonedSection.style.height = `${originalSection.offsetHeight * 0.75}px`;
+        }
         console.log(
           'calling inlineStylesRecursively for',
           originalSection.id,
           'as',
           sectionType
         );
-        inlineStylesRecursively(clonedSection, sectionType, index < 2 ? 0.75 : 1);
+        inlineStylesRecursively(clonedSection, sectionType, scaleFactor);
 
         // Log text content and font size of all elements within the cloned section
         clonedSection.querySelectorAll('*').forEach(el => {
@@ -371,19 +377,24 @@ const ClientFinancialReport = () => {
 
         await new Promise(resolve => setTimeout(resolve, 300));
 
+        const sectionWidth = originalSection.offsetWidth;
+        const sectionHeight = originalSection.offsetHeight * scaleFactor;
+
         const canvas = await html2canvas(clonedSection, {
           foreignObjectRendering: false,
           useCORS: true,
           logging: false,
           allowTaint: true,
-          scale: 4
+          scale: 4,
+          width: sectionWidth,
+          height: sectionHeight
         });
         document.body.removeChild(clonedSection);
         const imgData = canvas.toDataURL('image/jpeg', 0.6);
 
         // Adjust image size to fit PDF
         const imgWidth = pdfWidth - 20; // margins
-        const imgHeight = (canvas.height * imgWidth) / canvas.width;
+        const imgHeight = (sectionHeight * imgWidth) / sectionWidth;
 
         // Check if we need a new page
         if (yOffset + 10 + imgHeight > pdfHeight) {


### PR DESCRIPTION
## Summary
- Scale first two report sections when cloning for PDF generation
- Use scaled section dimensions with html2canvas and update y-offset calculations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3e0ec24cc8333bc7c45eeb6978357