### PR TITLE
Remove conditional report scaling

### DIFF
--- a/src/pages/ClientFinancialReport.jsx
+++ b/src/pages/ClientFinancialReport.jsx
@@ -271,7 +271,7 @@ const ClientFinancialReport = () => {
         }
         const originalSection = sec.current || sec;
         logDev('Processing section:', originalSection.id, originalSection);
-        const scaleFactor = index < 2 ? 0.75 : 1;
+        const scaleFactor = 1;
 
         let isHeader = false;
         let headerReason = '';
@@ -315,11 +315,6 @@ const ClientFinancialReport = () => {
         clonedSection.style.position = 'absolute';
         clonedSection.style.left = '-10000px';
         document.body.appendChild(clonedSection);
-        if (index < 2) {
-          clonedSection.style.transform = 'scale(0.75)';
-          clonedSection.style.transformOrigin = 'top left';
-          clonedSection.style.height = `${originalSection.offsetHeight * 0.75}px`;
-        }
         console.log(
           'calling inlineStylesRecursively for',
           originalSection.id,

--- a/src/pages/__tests__/ReportFontScale.test.jsx
+++ b/src/pages/__tests__/ReportFontScale.test.jsx
@@ -2,7 +2,7 @@ import { test, expect } from 'vitest';
 import { JSDOM } from 'jsdom';
 import { inlineStylesRecursively } from '../ClientFinancialReport.jsx';
 
-test('first two sections scale fonts by 75%', () => {
+test('sections retain original font size when scaleFactor is 1', () => {
   const dom = new JSDOM(`
     <div id="report">
       <section id="report-header"><p style="font-size:16px">Header</p></section>
@@ -12,13 +12,13 @@ test('first two sections scale fonts by 75%', () => {
   `);
   const report = dom.window.document.getElementById('report');
   const sections = Array.from(report.children);
-  sections.forEach((sec, index) => {
-    inlineStylesRecursively(sec, 'body', index < 2 ? 0.75 : 1);
+  sections.forEach(sec => {
+    inlineStylesRecursively(sec, 'body', 1);
   });
   const headerFont = report.querySelector('#report-header p').style.fontSize;
   const clientFont = report.querySelector('#client-info p').style.fontSize;
   const otherFont = report.querySelector('#other p').style.fontSize;
-  expect(headerFont).toBe('12px');
-  expect(clientFont).toBe('12px');
+  expect(headerFont).toBe('16px');
+  expect(clientFont).toBe('16px');
   expect(otherFont).toBe('16px');
 });


### PR DESCRIPTION
## Summary
- Render all report sections at full size by removing conditional scaling
- Update font-scaling test to reflect full-size rendering

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68a406a02f5c8333be85a0a7011f55ad