### PR TITLE
Fix Vite base path for Netlify build

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,3 @@
+[build]
+  publish = "dist"
+  command = "npm run build"

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,7 +4,7 @@ import path from 'path';
 
 export default defineConfig({
   plugins: [react()],
-  base: './',
+  base: '/',
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src')


### PR DESCRIPTION
## Summary
- build assets relative to site root by setting `base: '/'`
- add Netlify config to publish `dist`

## Testing
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b62621a818833386fd77d6cc42951f